### PR TITLE
Enhance template variable formatting and preserve table styling

### DIFF
--- a/template_reports/admin/generate.py
+++ b/template_reports/admin/generate.py
@@ -156,6 +156,14 @@ class ReportGenerationAdminMixin(admin.ModelAdmin):
         # Check that we only have ONE top-level object context key required.
         object_fields_required = context_requirements["object_fields"]
         simple_fields_required = context_requirements["simple_fields"]
+        if not object_fields_required:
+            self.message_user(
+                request,
+                f"The report template does not have any top-level object fields, it needs exactly "
+                f"one: {object_fields_required}.",
+                level=messages.ERROR,
+            )
+            return redirect("..")
         if len(object_fields_required) > 1:
             self.message_user(
                 request,

--- a/template_reports/models/base.py
+++ b/template_reports/models/base.py
@@ -74,6 +74,13 @@ class BaseReportDefinition(models.Model):
         Save the generated report file as ReportRun.
         """
 
+        # Enrich the context with the global context
+        global_context = self.get_global_context()
+        context = {
+            **global_context,
+            **context,
+        }
+
         # Get the file as a usable stream
         file_stream = self.get_file_stream()
 
@@ -139,6 +146,16 @@ class BaseReportDefinition(models.Model):
 
         # Success
         return None
+
+    def get_global_context(self):
+        """
+        Return the global context for the report. This can be used to
+        provide additional data to the template rendering process.
+
+        Override this if context needs to be pulled from elsewhere too.
+        """
+        config = self.config or {}
+        return config.get("context", {})
 
     def build_filename(
         self,

--- a/template_reports/office_renderer/context_extractor.py
+++ b/template_reports/office_renderer/context_extractor.py
@@ -52,10 +52,10 @@ def extract_context_keys(template) -> dict[str, list[str]]:
     simple_fields = set()
     object_fields = set()
 
+    # Build a list of all texts on all slides.
+    texts = []
     for slide in prs.slides:
         for shape in slide.shapes:
-            # Build a list of all texts on this slide.
-            texts = []
 
             # Process text frames.
             if hasattr(shape, "text_frame"):

--- a/template_reports/templating/formatting.py
+++ b/template_reports/templating/formatting.py
@@ -15,6 +15,8 @@ Supported tokens:
   - ss   -> %S (second)
 """
 
+from .exceptions import BadTagException
+
 
 def convert_date_format(custom_format):
     mapping = {
@@ -35,3 +37,59 @@ def convert_date_format(custom_format):
     for token in sorted(mapping.keys(), key=lambda k: -len(k)):
         custom_format = custom_format.replace(token, mapping[token])
     return custom_format
+
+
+def format_value(value, format_expr):
+    """
+    Formats a value using a custom format string.
+
+    This function supports:
+      - Date formatting with custom tokens (e.g., 'MMMM, dd, YYYY' or '%Y-%m-%d')
+      - Numeric formatting (e.g., '.2f' for two decimal places)
+      - String case transformations ('upper', 'lower', 'capitalize')
+
+    Options for format_expr:
+        Date/time:    %Y, %m, %d, %A, %a, %I, %H, %M, %S, %p, MMMM, MMM, MM, dd, etc.
+        Numeric:      .2f, .0f, d, etc.
+        String case:  upper, lower, capitalize
+
+    Examples:
+       %Y-%m-%d         # Formats current date as '2024-06-01'
+       MMMM, dd, YYYY   # Formats as 'June, 01, 2024'
+       .2f              # Formats number as '3.14'
+       upper            # Converts string to uppercase
+       lower            # Converts string to lowercase
+       capitalize       # Converts string to uppercase (same as 'upper')
+       title            # Converts string to title case (all word initials uppercase)
+       %A               # Formats date as full weekday name, e.g., 'Monday'
+       %I:%M %p         # Formats time as '01:30 PM'
+    """
+    try:
+        # Handle uppercase/lowercase.
+        if format_expr in ("upper", "capitalize"):
+            return str(value).upper()
+        if format_expr == "lower":
+            return str(value).lower()
+        if format_expr == "title":
+            return str(value).title()
+
+        # Convert the format string to a date format if necessary.
+        format_expr = convert_date_format(format_expr)
+
+        # Now use the default python formatting for dates, numbers, etc
+        return format(value, format_expr)
+
+    except Exception as e:
+        raise BadTagException(
+            f"Error formatting value '{value}' with format '{format_expr}': {str(e)}"
+        )
+
+    return value
+
+    # If the format string contains a comma, split it to retrieve multiple attributes.
+    # elif "," in format_expr:
+    #     attrs = [a.strip() for a in format_expr.split(",")]
+    #     return tuple(
+    #         resolve_tag(f"{value_expr}.{attr}", context, perm_user=perm_user)
+    #         for attr in attrs
+    #     )

--- a/template_reports/templating/resolve.py
+++ b/template_reports/templating/resolve.py
@@ -2,7 +2,7 @@ import re
 import datetime
 
 from .exceptions import BadTagException, MissingDataException, TagCallableException
-from .formatting import convert_date_format
+from .formatting import convert_date_format, format_value
 from .parse import get_nested_attr, evaluate_condition, parse_callable_args
 from .permissions import enforce_permissions
 
@@ -39,6 +39,8 @@ def resolve_formatted_tag(expr: str, context, perm_user=None):
              {{ now | %Y-%m-%d }}         will return the current date formatted as specified.
              {{ now | MMMM, dd, YYYY }}   will return the current date formatted as specified.
              {{ value | .2f }}            will return the value formatted to two decimal places.
+             {{ value | upper }}          will return the value in upper case.
+             {{ value | lower }}          will return the value in lower case.
 
       9. [CURRENTLY DISABLED] Use of a pipe operator to retrieve more than one attribute from an object/dictionary
          and return a tuple of values. For example:
@@ -129,22 +131,7 @@ def resolve_formatted_tag(expr: str, context, perm_user=None):
 
     # If a format string is provided...
     if format_expr:
-        try:
-            # Convert the format string to a date format if necessary.
-            format_expr = convert_date_format(format_expr)
-            value = format(value, format_expr)
-        except Exception as e:
-            raise BadTagException(
-                f"Error formatting value '{value}' with format '{format_expr}': {str(e)}"
-            )
-
-        # If the format string contains a comma, split it to retrieve multiple attributes.
-        # elif "," in format_expr:
-        #     attrs = [a.strip() for a in format_expr.split(",")]
-        #     return tuple(
-        #         resolve_tag(f"{value_expr}.{attr}", context, perm_user=perm_user)
-        #         for attr in attrs
-        #     )
+        value = format_value(value, format_expr)
 
     return value
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -2,79 +2,136 @@ import unittest
 from unittest.mock import patch
 
 from template_reports.office_renderer.exceptions import TableError
+import template_reports.office_renderer.tables as tables
 from template_reports.office_renderer.tables import (
-    process_table_cell,
     clone_row_with_value,
     fill_column_with_list,
+    process_table_cell,
 )
-from template_reports.templating import process_text
 
 
-# Define a DummyRequestUser for these tests.
+# ——— Dummy helpers ————————————————————————————————————————
+
+
 class DummyRequestUser:
     def has_perm(self, perm, obj):
         return True
 
 
-# Define dummy XML element classes to simulate pptx objects.
-
-
 class DummyElement:
-    def __init__(self, text):
+    """Bare‑bones XML element stand‑in."""
+
+    def __init__(self, text=""):
         self.text = text
         self.parent = None
+        self.text_frame = None
 
     def getparent(self):
         return self.parent
 
-    # Add this method so that _Cell can call it.
+    # python‑pptx internal helper our *_Cell wrapper expects
     def get_or_add_txBody(self):
         return self
 
-    # Added clear_content to simulate real behavior.
-    def clear_content(self):
-        self.text = ""
+    def __repr__(self):
+        return f"DummyElement({self.text!r})"
 
-    # Add this to avoid AttributeError when cell.text is assigned:
-    def add_p(self):
-        # Return a new dummy paragraph element
-        return DummyElement("")
 
-    def _append_text(self, txt, p):
-        p.text += txt
+class DummyRun:
+    def __init__(self, text=""):
+        self.text = text
+        self._r = DummyElement(text)
+        self.font = type("Font", (), {})()
+        self.font.bold = False
+        self.font.size = 12
+
+
+class DummyParagraph:
+    def __init__(self, text=""):
+        self._p = DummyElement("")  # underlying XML element placeholder
+        self.runs = [DummyRun(text)] if text else []
+
+    def clear(self):
+        self.runs = []
+
+    def add_run(self):
+        r = DummyRun()
+        self.runs.append(r)
+        return r
+
+
+class DummyTextFrame:
+    def __init__(self, paragraphs=None):
+        self.paragraphs = paragraphs or []
+        if not self.paragraphs:
+            self.paragraphs.append(DummyParagraph(""))
+
+    def add_paragraph(self):
+        p = DummyParagraph("")
+        self.paragraphs.append(p)
         return p
 
-    # NEW: append_text method to satisfy the call from pptx.text.text.
-    def append_text(self, txt):
-        self.text += txt
-        return self
 
-    def __repr__(self):
-        return f"DummyElement(text={self.text})"
+class DummyCell:
+    """Substitute for pptx.table._Cell used inside the library code."""
+
+    def __init__(self, target, parent):
+        self._target = target  # DummyElement
+        self._parent = parent  # DummyRow
+        if target.text_frame is None:
+            target.text_frame = DummyTextFrame([DummyParagraph(target.text)])
+        self.text_frame = target.text_frame
+
+    @property
+    def text(self):
+        # Derive from runs
+        return "".join(r.text for p in self.text_frame.paragraphs for r in p.runs)
+
+    @text.setter
+    def text(self, value):
+        if not self.text_frame.paragraphs:
+            self.text_frame.paragraphs.append(DummyParagraph(""))
+        p = self.text_frame.paragraphs[0]
+        if p.runs:
+            p.runs[0].text = value
+            for extra in p.runs[1:]:
+                extra.text = ""
+        else:
+            p.runs.append(DummyRun(value))
+        self._target.text = value  # sync back
 
 
 class DummyRow(list):
-    """A dummy row element (list of cell XML elements)."""
-
     def __init__(self, cells, parent=None):
         super().__init__(cells)
-        for cell in cells:
-            cell.parent = self
-        self.parent = parent  # parent table
+        for c in cells:
+            c.parent = self
+        self.parent = parent
 
     def getparent(self):
         return self.parent
 
     def __deepcopy__(self, memo):
-        # For the purpose of testing, we use deepcopy on a new DummyRow with copied cells.
-        copied_cells = [DummyElement(cell.text) for cell in self]
-        new_row = DummyRow(copied_cells, parent=self.parent)
-        return new_row
+        copied_cells = []
+        for c in self:
+            nc = DummyElement(c.text)
+            if getattr(c, "text_frame", None) is not None:
+                new_paras = []
+                for p in c.text_frame.paragraphs:
+                    new_p = DummyParagraph("")
+                    new_p.runs = []
+                    for r in p.runs:
+                        new_r = DummyRun(r.text)
+                        new_r.font.bold = r.font.bold
+                        new_r.font.size = r.font.size
+                        new_p.runs.append(new_r)
+                    new_paras.append(new_p)
+                nc.text_frame = DummyTextFrame(new_paras)
+            copied_cells.append(nc)
+        return DummyRow(copied_cells, parent=self.parent)
 
 
 class DummyTable:
-    """A dummy table element that holds rows."""
-
     def __init__(self):
         self.rows = []
 
@@ -89,205 +146,136 @@ class DummyTable:
         return f"DummyTable(rows={self.rows})"
 
 
-class DummyCell:
-    """
-    A patched dummy version of pptx.table._Cell.
-    Simply wraps a target DummyElement; setting text updates target.text.
-    Avoids calling super() and related issues.
-    """
+class DummyCellWrapper:
+    """What the library receives in real use (shape.table.cell)."""
 
-    def __init__(self, target, parent):
-        self.target = target
-        self.parent = parent
+    def __init__(self, text=""):
+        self._tc = DummyElement(text)
+        self._tc.text_frame = DummyTextFrame([DummyParagraph(text)])
+        self.text_frame = self._tc.text_frame
 
     @property
     def text(self):
-        return self.target.text
+        return "".join(r.text for p in self.text_frame.paragraphs for r in p.runs)
 
     @text.setter
     def text(self, value):
-        self.target.text = value
+        p = self.text_frame.paragraphs[0]
+        if p.runs:
+            p.runs[0].text = value
+            for extra in p.runs[1:]:
+                extra.text = ""
+        else:
+            p.runs.append(DummyRun(value))
+        self._tc.text = value
 
 
-# Dummy cell for process_table_cell tests.
-class DummyTextFrame:
-    def __init__(self, paragraphs):
-        self.paragraphs = paragraphs
-
-
-class DummyParagraph:
-    def __init__(self, text):
-        self.text = text
-        self.runs = [DummyRun(text)]
-        self._p = DummyElement("")  # dummy underlying XML
-
-    def clear(self):
-        """Clear existing runs."""
-        self.runs = []
-
-    def add_run(self):
-        """Add a new run and return it."""
-        run = DummyRun("")
-        self.runs.append(run)
-        return run
-
-
-class DummyRun:
-    def __init__(self, text):
-        self.text = text
-        self._r = DummyElement(text)
-
-
-# For process_text, use the actual function from templating/core.py
-
-
-class DummyCellWrapper:
-    """
-    Dummy cell simulating a table cell.
-    Has an attribute _tc representing the underlying XML,
-    a text_frame with paragraphs, and a text attribute.
-    """
-
-    def __init__(self, text):
-        self.text = text
-        # For testing, _tc will be a DummyElement.
-        self._tc = DummyElement(text)
-        self.text_frame = DummyTextFrame([DummyParagraph(text)])
-
-    def __repr__(self):
-        return f"DummyCellWrapper(text={self.text})"
+# ——— Test cases ——————————————————————————————————————————
 
 
 class TestTables(unittest.TestCase):
 
-    # --- Tests for clone_row_with_value ---
+    # --- clone_row_with_value ---
+    @patch("pptx.table._Cell", new=DummyCell)
     @patch("template_reports.office_renderer.tables._Cell", new=DummyCell)
     def test_clone_row_with_value_normal(self):
-        # Create a dummy row with three cells.
-        cell1 = DummyElement("A")
-        cell2 = DummyElement("B")
-        cell3 = DummyElement("C")
-        original_row = DummyRow([cell1, cell2, cell3])
-        # Clone the row updating cell index 1 to "NEW".
-        cloned = clone_row_with_value(original_row, 1, "NEW")
-        # Verify cloned row cell 1's text.
-        self.assertEqual(cloned[1].text, "NEW")
-        # Ensure the other cells remain identical to original (copied value, not same reference)
-        self.assertEqual(cloned[0].text, "A")
-        self.assertEqual(cloned[2].text, "C")
-        # Original row remains unchanged.
-        self.assertEqual(original_row[1].text, "B")
+        row = DummyRow([DummyElement("A"), DummyElement("B"), DummyElement("C")])
+        cloned = clone_row_with_value(row, 1, "NEW")
+        vals = [DummyCell(c, cloned).text for c in cloned]
+        self.assertEqual(vals, ["A", "NEW", "C"])
+        self.assertEqual(row[1].text, "B")
 
+    @patch("pptx.table._Cell", new=DummyCell)
+    @patch("template_reports.office_renderer.tables._Cell", new=DummyCell)
     def test_clone_row_with_value_out_of_range(self):
-        # If cell_index is out of range, row should remain unchanged.
-        cell1 = DummyElement("X")
-        original_row = DummyRow([cell1])
         with self.assertRaises(TableError):
-            clone_row_with_value(original_row, 5, "NEW")
+            clone_row_with_value(DummyRow([DummyElement("X")]), 5, "NOPE")
 
-    # --- Tests for fill_column_with_list ---
+    # --- fill_column_with_list ---
+    @patch("pptx.table._Cell", new=DummyCell)
     @patch("template_reports.office_renderer.tables._Cell", new=DummyCell)
     def test_fill_column_with_list_normal(self):
-        # Create a dummy table structure with one row and one cell.
-        cell_wrapper = DummyCellWrapper("ORIGINAL")
-        row = DummyRow([cell_wrapper._tc])
-        table = DummyTable()
-        table.append(row)
-        # Call fill_column_with_list on the cell with a list of items.
-        items = ["First", "Second", "Third"]
-        fill_column_with_list(cell_wrapper, items)
-        # The original cell gets updated with first item.
-        self.assertEqual(cell_wrapper.text, "First")
-        # The table should now have the original row plus 2 new rows.
-        self.assertEqual(
-            len(table.rows), 3
-        )  # Our dummy rows are appended to the XML table element
-        # But our function uses: table_element.append(new_row_element)
-        # So we simulate that by checking row.parent appended rows.
-        # For this test, we simulate by creating a dummy table and manually setting parent's relationship.
-        row.parent = table
-        initial_row_count = len(table.rows)
-        # Append additional row using clone_row_with_value.
-        new_row = clone_row_with_value(row, 0, "Second")
-        table.append(new_row)
-        self.assertEqual(len(table.rows), initial_row_count + 1)
-        # Verify that the cloned row's cell at index 0 has text "Second".
-        self.assertEqual(new_row[0].text, "Second")
+        cw = DummyCellWrapper("ORIGINAL")
+        row = DummyRow([cw._tc])
+        tbl = DummyTable()
+        tbl.append(row)
+        fill_column_with_list(cw, ["First", "Second", "Third"])
+        self.assertEqual(cw.text, "First")
+        self.assertEqual(len(tbl.rows), 3)
+        self.assertEqual(DummyCell(tbl.rows[1][0], tbl.rows[1]).text, "Second")
+        self.assertEqual(DummyCell(tbl.rows[2][0], tbl.rows[2]).text, "Third")
 
+    @patch("pptx.table._Cell", new=DummyCell)
+    @patch("template_reports.office_renderer.tables._Cell", new=DummyCell)
     def test_fill_column_with_list_empty(self):
-        cell_wrapper = DummyCellWrapper("NonEmpty")
-        # When items list is empty, cell text should be set to empty string.
-        fill_column_with_list(cell_wrapper, [])
-        self.assertEqual(cell_wrapper.text, "")
+        cw = DummyCellWrapper("NonEmpty")
+        row = DummyRow([cw._tc])
+        tbl = DummyTable()
+        tbl.append(row)
+        fill_column_with_list(cw, [])
+        self.assertEqual(cw.text, "")
 
-    # --- Tests for process_table_cell ---
-    def test_process_table_cell_pure_placeholder(self):
-        # For a pure placeholder, process_table_cell should use table mode.
-        placeholder = "{{ test }}"
-        cell_wrapper = DummyCellWrapper(placeholder)
+    @patch("pptx.table._Cell", new=DummyCell)
+    @patch("template_reports.office_renderer.tables._Cell", new=DummyCell)
+    def test_fill_column_with_list_preserves_formatting(self):
+        class BR(DummyRun):
+            def __init__(self, text):
+                super().__init__(text)
+                self.font.bold = True
+                self.font.size = 22
 
-        # Set up a dummy table structure:
-        # Create a dummy row containing the cell's XML element.
-        row = DummyRow([cell_wrapper._tc])
-        # Create a dummy table and append the new row.
-        dummy_table = DummyTable()
-        dummy_table.append(row)
+        p = DummyParagraph("")
+        p.runs = [BR("X")]
+        cw = DummyCellWrapper("X")
+        cw.text_frame = DummyTextFrame([p])
+        cw._tc.text_frame = cw.text_frame
+        tbl = DummyTable()
+        tbl.append(DummyRow([cw._tc]))
+        fill_column_with_list(cw, ["A", "B"])
+        run0 = cw.text_frame.paragraphs[0].runs[0]
+        self.assertTrue(run0.font.bold)
+        self.assertEqual(run0.font.size, 22)
 
-        # Now, cell_wrapper._tc.getparent() returns row and row.getparent() returns dummy_table.
-
-        # Define a dummy process_text that returns a list.
-        def dummy_process_text(text, context, perm_user, mode, fail_if_empty):
-            if mode == "table":
-                return ["Row1", "Row2"]
-            return "Row1"
-
-        original_process_text = process_text
-        try:
-            from template_reports.office_renderer import tables
-
-            tables.process_text = dummy_process_text
-            context = {"test": "ignored"}
-            process_table_cell(cell_wrapper, context, None)
-            # Since dummy_process_text returned a list, the original cell should be updated to first item.
-            self.assertEqual(cell_wrapper.text, "Row1")
-        finally:
-            tables.process_text = original_process_text
-
-    def test_process_table_cell_mixed_text(self):
-        # For a cell that is not a pure placeholder, process_table_cell should call
-        # process_paragraph and update the paragraph's runs.
-        non_pure = "Prefix {{ test }} Suffix {{ test }}"
-        cell_wrapper = DummyCellWrapper(non_pure)
-        import template_reports.office_renderer.tables as tables_module
-
-        # Save the original local binding for process_paragraph in tables module.
-        original_para_processor = tables_module.__dict__.get("process_paragraph")
+    # --- process_table_cell (mixed) ---
+    @patch(
+        "template_reports.office_renderer.tables.get_matching_tags",
+        return_value=["x", "y"],
+    )
+    def test_process_table_cell_mixed_text(self, *_):
+        cw = DummyCellWrapper("Pre {{ x }} Post")
+        orig = tables.process_paragraph
         try:
 
-            def dummy_para_process(paragraph, context, perm_user, mode):
-                # Get full text from paragraph runs.
-                full_text = "".join(run.text for run in paragraph.runs)
-                # Replace the placeholder with VALUE.
-                new_text = full_text.replace("{{ test }}", "VALUE")
-                # Clear runs and add a new run with new text.
+            def dummy_pp(paragraph, context, perm_user, mode):
                 paragraph.clear()
-                paragraph.add_run().text = new_text
+                paragraph.add_run().text = "Repl"
 
-            # Override the local process_paragraph reference in tables module.
-            tables_module.__dict__["process_paragraph"] = dummy_para_process
-
-            context = {"test": "VALUE"}
-            # Call process_table_cell (which will use our dummy process_paragraph).
-            from template_reports.office_renderer.tables import process_table_cell
-
-            process_table_cell(cell_wrapper, context, perm_user=None)
-
-            # Retrieve updated text from the first paragraph's first run.
-            updated_text = cell_wrapper.text_frame.paragraphs[0].runs[0].text
-            self.assertIn("VALUE", updated_text)
+            tables.process_paragraph = dummy_pp
+            process_table_cell(cw, {}, None)
+            self.assertEqual(cw.text, "Repl")
         finally:
-            # Restore the original process_paragraph.
-            tables_module.__dict__["process_paragraph"] = original_para_processor
+            tables.process_paragraph = orig
+
+    # --- process_table_cell (pure) ---
+    @patch("pptx.table._Cell", new=DummyCell)
+    @patch("template_reports.office_renderer.tables._Cell", new=DummyCell)
+    @patch(
+        "template_reports.office_renderer.tables.process_text", return_value=["R1", "R2"]
+    )
+    @patch(
+        "template_reports.office_renderer.tables.get_matching_tags", return_value=["only"]
+    )
+    def test_process_table_cell_pure_placeholder(self, *_):
+        cw = DummyCellWrapper("{{ only }}")
+        r = DummyRow([cw._tc])
+        tbl = DummyTable()
+        tbl.append(r)
+        cw._tc.parent = r
+        r.parent = tbl
+        process_table_cell(cw, {}, DummyRequestUser())
+        self.assertEqual(cw.text, "R1")
+        # second row exists but is cleared, not set
+        self.assertEqual(DummyCell(tbl.rows[1][0], tbl.rows[1]).text, "")
 
 
 if __name__ == "__main__":

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -343,6 +343,50 @@ class TestTemplatingNormalMode(unittest.TestCase):
         )
         self.assertEqual(result, "8.15")
 
+    def test_string_upper_formatting(self):
+        self.context["value"] = "hello world"
+        tpl = "{{ value | upper }}"
+        result = process_text(
+            tpl,
+            self.context,
+            perm_user=None,
+            mode="normal",
+        )
+        self.assertEqual(result, "HELLO WORLD")
+
+    def test_string_lower_formatting(self):
+        self.context["value"] = "Hello World"
+        tpl = "{{ value | lower }}"
+        result = process_text(
+            tpl,
+            self.context,
+            perm_user=None,
+            mode="normal",
+        )
+        self.assertEqual(result, "hello world")
+
+    def test_string_capitalize_formatting(self):
+        self.context["value"] = "hello world"
+        tpl = "{{ value | capitalize }}"
+        result = process_text(
+            tpl,
+            self.context,
+            perm_user=None,
+            mode="normal",
+        )
+        self.assertEqual(result, "HELLO WORLD")
+
+    def test_string_title_formatting(self):
+        self.context["value"] = "hello world"
+        tpl = "{{ value | title }}"
+        result = process_text(
+            tpl,
+            self.context,
+            perm_user=None,
+            mode="normal",
+        )
+        self.assertEqual(result, "Hello World")
+
 
 # ----- Test Case for Table Mode -----
 class TestTemplatingTableMode(unittest.TestCase):


### PR DESCRIPTION
Introduce support for uppercasing and other string transformations in template variable formatting. Address table row styling to ensure it matches the original template. Fixes bugs.

Fixes #20, #21