### PR TITLE
Make ReportRun admin readonly and improve operator extraction

### DIFF
--- a/template_reports/admin/base.py
+++ b/template_reports/admin/base.py
@@ -43,6 +43,14 @@ class ReportRunAdmin(AdminWithFileUrl):
     autocomplete_fields = ("report_definition",)
     search_fields = ("report_definition__name",)
 
+    readonly_fields = (
+        "file_name",
+        "report_definition",
+        "created",
+        "modified",
+        "data",
+    )
+
     list_display = (
         "file_name",
         "file_link",


### PR DESCRIPTION
Set the ReportRun admin fields to readonly to prevent modifications. Enhance mathematical operator extraction to handle expressions with brackets more effectively.