### PR TITLE
Add flexible image replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Django Template Reports is a Django application that turns PowerPoint (PPTX) and
 * **Configurable filenames** using ``config.filename_template`` in ``ReportDefinition``.
 * **Global context** injection for values that should always be available.
 * **Context extraction** to inspect templates and determine which context keys are required.
-* **Image placeholders** – shapes or cells starting with ``%image% URL`` are replaced by an image downloaded from that URL.
+* **Image placeholders** – shapes or cells starting with ``%imagesqueeze%`` or ``%image%`` are replaced by an image downloaded from the provided URL.
 
 ## Codebase Overview
 
@@ -23,7 +23,7 @@ Django Template Reports is a Django application that turns PowerPoint (PPTX) and
 
 * ``models/`` – base classes ``ReportDefinition`` and ``ReportRun`` plus utilities for file storage.
 * ``admin/`` – Django admin classes and views used to generate reports and download them in bulk.
-* ``office_renderer/`` – logic for rendering PPTX and XLSX files.  This handles text boxes, tables, charts, worksheets and the new `%image%` directives.
+* ``office_renderer/`` – logic for rendering PPTX and XLSX files.  This handles text boxes, tables, charts, worksheets and the `%image%`/`%imagesqueeze%` directives.
 * ``templating/`` – the template engine responsible for parsing and evaluating expressions.
 * ``templates/`` and ``raw_templates/`` – the admin templates and example Office templates.
 * ``tests/`` – the test suite.
@@ -42,9 +42,10 @@ Template files are just normal PowerPoint or Excel documents.  No coding or macr
    * `{{ amount * 1.15 }}` – perform calculations.
    * `{{ price | .2f }}` or `{{ name | upper }}` – apply formatting filters.
 3. **Repeat rows or slides for lists.** If a placeholder by itself resolves to a list, extra rows (or slides) will be created so that each item appears separately.  This is how you build tables from querysets.
-4. **Add images.** To include an image from a URL, create a text box or cell that starts with `%image%` followed by the address:
+4. **Add images.** To include an image from a URL, create a text box or cell that starts with `%image%` or `%imagesqueeze%` followed by the address:
    `%image% https://example.com/logo.png`
-   The placeholder will be replaced by the downloaded image when the report is generated.
+   `%imagesqueeze% https://example.com/logo.png`
+   The former keeps the image's aspect ratio while fitting it inside the shape. The latter squeezes the image to exactly fill the shape.
 5. **Save the file** and register it in the Django admin as a report template.
 
 You can experiment with the example files in `template_reports/raw_templates` to see common patterns.  Remember that all placeholders are plain text—avoid formulas or punctuation that might confuse the parser.

--- a/template_reports/admin/generate.py
+++ b/template_reports/admin/generate.py
@@ -167,16 +167,20 @@ class ReportGenerationAdminMixin(admin.ModelAdmin):
             self.message_user(
                 request,
                 f"The report template must have exactly one top-level object field among all its "
-                f"placeholders, but we found {object_fields_required}.",
+                f"placeholders, but we found `{object_fields_required}`.",
                 level=messages.ERROR,
             )
             return redirect("..")
         object_key_required = object_fields_required[0]
 
+        # Get defaults for the extra simple fields from the report definition.
+        simple_field_defaults = report_def.get_global_context()
+
         form_kwargs = dict(
             fixed_field=object_key_required,
             extra_simple_fields=simple_fields_required,
             fixed_queryset=qs,
+            initial=simple_field_defaults
         )
 
         if request.method == "POST":

--- a/template_reports/office_renderer/images.py
+++ b/template_reports/office_renderer/images.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from io import BytesIO
 from urllib.request import urlopen
 
-from pptx.enum.shapes import MSO_SHAPE_TYPE
-from pptx.util import Inches
 from openpyxl.drawing.image import Image as XLImage
 from PIL import Image as PILImage
 
@@ -87,8 +85,8 @@ def replace_shape_with_image(
         pic = slide.shapes.add_picture(BytesIO(data), left, top, width=width, height=height)
     else:
         pic = slide.shapes.add_picture(BytesIO(data), left, top)
-        native_w = pic.image.width
-        native_h = pic.image.height
+        with PILImage.open(BytesIO(data)) as pil_img:
+            native_w, native_h = pil_img.size
         w_ratio = width / native_w
         h_ratio = height / native_h
         scale = min(w_ratio, h_ratio)

--- a/template_reports/office_renderer/images.py
+++ b/template_reports/office_renderer/images.py
@@ -4,44 +4,72 @@ from io import BytesIO
 from urllib.request import urlopen
 
 from pptx.enum.shapes import MSO_SHAPE_TYPE
+from pptx.util import Inches
 from openpyxl.drawing.image import Image as XLImage
+from PIL import Image as PILImage
 
+from ..templating import process_text
 from .exceptions import ImageError
 
 
-def extract_image_url(text: str | None) -> str | None:
-    """Return the image URL if *text* starts with the %image% directive."""
+IMAGE_DIRECTIVES = {
+    "%image%": "fit",
+    "%imagesqueeze%": "squeeze",
+}
+
+
+def extract_image_directive(text: str | None) -> tuple[str | None, str | None]:
+    """Return (url, mode) if *text* starts with an image directive."""
     if not text:
-        return None
+        return None, None
     stripped = text.strip()
-    if not stripped.lower().startswith("%image%"):
-        return None
-    url = stripped[len("%image%"):].strip()
-    return url or None
+    lowered = stripped.lower()
+    for marker, mode in IMAGE_DIRECTIVES.items():
+        if lowered.startswith(marker):
+            url = stripped[len(marker) :].strip()
+            return (url or None, mode)
+    return None, None
+
+
+def extract_image_url(text: str | None) -> str | None:
+    """Backward compatible helper returning only the URL."""
+    url, _ = extract_image_directive(text)
+    return url
 
 
 def should_replace_shape_with_image(shape) -> bool:
     """Return True if the shape text indicates an image placeholder."""
     if not hasattr(shape, "text_frame"):
         return False
-    return extract_image_url(shape.text_frame.text) is not None
+    url, _ = extract_image_directive(shape.text_frame.text)
+    return url is not None
 
 
 def should_replace_cell_with_image(cell) -> bool:
     """Return True if the cell value indicates an image placeholder."""
     if not isinstance(cell.value, str):
         return False
-    return extract_image_url(cell.value) is not None
+    url, _ = extract_image_directive(cell.value)
+    return url is not None
 
-def replace_shape_with_image(shape, slide, url: str | None = None):
-    """Replace *shape* with an image, keeping its size and position."""
+def replace_shape_with_image(
+    shape,
+    slide,
+    context: dict,
+    perm_user=None,
+    url: str | None = None,
+    mode: str | None = None,
+):
+    """Replace *shape* with an image, keeping its position."""
 
-    if url is None:
+    if url is None or mode is None:
         if not hasattr(shape, "text_frame"):
             return
-        url = extract_image_url(shape.text_frame.text)
+        url, mode = extract_image_directive(shape.text_frame.text)
     if not url:
         return
+
+    url = process_text(url, context=context, perm_user=perm_user, mode="normal")
 
     try:
         with urlopen(url) as resp:
@@ -55,7 +83,20 @@ def replace_shape_with_image(shape, slide, url: str | None = None):
     height = shape.height
     rotation = getattr(shape, "rotation", 0)
 
-    pic = slide.shapes.add_picture(BytesIO(data), left, top, width=width, height=height)
+    if mode == "squeeze":
+        pic = slide.shapes.add_picture(BytesIO(data), left, top, width=width, height=height)
+    else:
+        pic = slide.shapes.add_picture(BytesIO(data), left, top)
+        native_w = pic.image.width
+        native_h = pic.image.height
+        w_ratio = width / native_w
+        h_ratio = height / native_h
+        scale = min(w_ratio, h_ratio)
+        pic.width = int(native_w * scale)
+        pic.height = int(native_h * scale)
+        pic.left = int(left + (width - pic.width) / 2)
+        pic.top = int(top + (height - pic.height) / 2)
+
     pic.rotation = rotation
 
     # Remove the original shape
@@ -65,13 +106,22 @@ def replace_shape_with_image(shape, slide, url: str | None = None):
     return pic
 
 
-def replace_cell_with_image(cell, worksheet, url: str | None = None):
+def replace_cell_with_image(
+    cell,
+    worksheet,
+    context: dict,
+    perm_user=None,
+    url: str | None = None,
+    mode: str | None = None,
+):
     """Replace the cell's value with an image anchored at the cell."""
 
-    if url is None:
-        url = extract_image_url(cell.value if isinstance(cell.value, str) else None)
+    if url is None or mode is None:
+        url, mode = extract_image_directive(cell.value if isinstance(cell.value, str) else None)
     if not url:
         return
+
+    url = process_text(url, context=context, perm_user=perm_user, mode="normal")
 
     try:
         with urlopen(url) as resp:

--- a/template_reports/office_renderer/pptx.py
+++ b/template_reports/office_renderer/pptx.py
@@ -35,7 +35,12 @@ def render_pptx(template, context: dict, output, perm_user):
             # Check if this shape should be replaced with an image.
             if should_replace_shape_with_image(shape):
                 try:
-                    replace_shape_with_image(shape, slide)
+                    replace_shape_with_image(
+                        shape,
+                        slide,
+                        context=slide_context,
+                        perm_user=perm_user,
+                    )
                 except Exception as e:
                     errors.append(
                         f"Error processing image (slide {slide_number}): {e}"

--- a/template_reports/office_renderer/worksheets.py
+++ b/template_reports/office_renderer/worksheets.py
@@ -22,7 +22,12 @@ def process_worksheet(worksheet, context: dict, perm_user=None):
         for cell_idx, cell in enumerate(col):
             # If this cell contains an image directive, replace it and skip further processing.
             if should_replace_cell_with_image(cell):
-                replace_cell_with_image(cell, worksheet)
+                replace_cell_with_image(
+                    cell,
+                    worksheet,
+                    context=context,
+                    perm_user=perm_user,
+                )
                 continue
 
             # Process the cell value (with placeholders or otherwise)

--- a/tests/test_pptx_integration.py
+++ b/tests/test_pptx_integration.py
@@ -243,7 +243,7 @@ class TestRendererIntegration(unittest.TestCase):
 
         from PIL import Image
 
-        img = Image.new("RGB", (2, 2), color="red")
+        img = Image.new("RGB", (200, 100), color="red")  # Use different dimensions to test aspect ratio
         img_file = tempfile.mktemp(suffix=".png")
         img.save(img_file)
 

--- a/tests/test_pptx_integration.py
+++ b/tests/test_pptx_integration.py
@@ -211,7 +211,7 @@ class TestRendererIntegration(unittest.TestCase):
         self.assertIn("Result3: 30.0", txt)  # 10+5=15, 15*2=30
 
     def test_image_download_and_replace(self):
-        """A text box starting with %image% should be replaced by a picture."""
+        """A text box starting with %imagesqueeze% should be replaced by a picture."""
 
         from PIL import Image
 
@@ -221,7 +221,7 @@ class TestRendererIntegration(unittest.TestCase):
 
         slide = self.prs.slides.add_slide(self.prs.slide_layouts[5])
         box = slide.shapes.add_textbox(Inches(0.5), Inches(5), Inches(2), Inches(2))
-        box.text_frame.text = f"%image% file://{img_file}"
+        box.text_frame.text = f"%imagesqueeze% file://{img_file}"
 
         self.prs.save(self.temp_input)
 
@@ -235,6 +235,34 @@ class TestRendererIntegration(unittest.TestCase):
         self.assertEqual(pic_shape.shape_type, MSO_SHAPE_TYPE.PICTURE)
         self.assertEqual(pic_shape.width, box.width)
         self.assertEqual(pic_shape.height, box.height)
+
+        os.remove(img_file)
+
+    def test_image_download_and_fit(self):
+        """%image% should fit inside the shape keeping aspect ratio."""
+
+        from PIL import Image
+
+        img = Image.new("RGB", (2, 2), color="red")
+        img_file = tempfile.mktemp(suffix=".png")
+        img.save(img_file)
+
+        slide = self.prs.slides.add_slide(self.prs.slide_layouts[5])
+        box = slide.shapes.add_textbox(Inches(0.5), Inches(5), Inches(4), Inches(1))
+        box.text_frame.text = f"%image% file://{img_file}"
+
+        self.prs.save(self.temp_input)
+
+        rendered, errors = render_pptx(
+            self.temp_input, self.context, self.temp_output, perm_user=None
+        )
+        self.assertIsNone(errors)
+
+        prs_out = Presentation(rendered)
+        pic_shape = prs_out.slides[-1].shapes[-1]
+        self.assertEqual(pic_shape.shape_type, MSO_SHAPE_TYPE.PICTURE)
+        self.assertEqual(pic_shape.height, box.height)
+        self.assertLess(pic_shape.width, box.width)
 
         os.remove(img_file)
 

--- a/tests/test_slide_downloaded_image.py
+++ b/tests/test_slide_downloaded_image.py
@@ -57,7 +57,8 @@ class TestSlideDownloadedImage(unittest.TestCase):
 
         # Create non-square shape
         shape = self.slide.shapes.add_textbox(Inches(3), Inches(3), Inches(4), Inches(1))
-        shape.text_frame.text = f"%image% {{ img }}"
+        # Use explicit braces so the URL placeholder is passed through for processing
+        shape.text_frame.text = "%image% {{ img }}"
 
         replace_shape_with_image(shape, self.slide, context=self.context)
 

--- a/tests/test_slide_downloaded_image.py
+++ b/tests/test_slide_downloaded_image.py
@@ -22,7 +22,8 @@ class TestSlideDownloadedImage(unittest.TestCase):
         img = Image.new("RGB", (4, 4), color="red")
         self.temp_image = tempfile.mktemp(suffix=".png")
         img.save(self.temp_image)
-        self.textbox.text_frame.text = f"%image% file://{self.temp_image}"
+        self.textbox.text_frame.text = f"%imagesqueeze% file://{self.temp_image}"
+        self.context = {"img": f"file://{self.temp_image}"}
 
     def tearDown(self):
         if os.path.exists(self.temp_image):
@@ -32,7 +33,7 @@ class TestSlideDownloadedImage(unittest.TestCase):
         original_width = self.textbox.width
         original_height = self.textbox.height
 
-        replace_shape_with_image(self.textbox, self.slide)
+        replace_shape_with_image(self.textbox, self.slide, context=self.context)
 
         # Only one non-placeholder shape should remain and it should be a picture
         shapes = [
@@ -49,7 +50,31 @@ class TestSlideDownloadedImage(unittest.TestCase):
         mock_urlopen.side_effect = Exception("boom")
         self.textbox.text_frame.text = "%image% http://example.com/foo.png"
         with self.assertRaises(ImageError):
-            replace_shape_with_image(self.textbox, self.slide)
+            replace_shape_with_image(self.textbox, self.slide, context={})
+
+    def test_image_aspect_ratio_fitting(self):
+        """%image% should keep aspect ratio inside the shape."""
+
+        # Create non-square shape
+        shape = self.slide.shapes.add_textbox(Inches(3), Inches(3), Inches(4), Inches(1))
+        shape.text_frame.text = f"%image% {{ img }}"
+
+        replace_shape_with_image(shape, self.slide, context=self.context)
+
+        pic = [s for s in self.slide.shapes if s.shape_type == MSO_SHAPE_TYPE.PICTURE][-1]
+        self.assertEqual(pic.height, shape.height)
+        self.assertLess(pic.width, shape.width)
+
+    def test_placeholder_in_url(self):
+        """URL expressions should be processed using process_text."""
+
+        shape = self.slide.shapes.add_textbox(Inches(5), Inches(1), Inches(2), Inches(2))
+        shape.text_frame.text = "%imagesqueeze% {{ img }}"
+
+        replace_shape_with_image(shape, self.slide, context=self.context)
+
+        pic = [s for s in self.slide.shapes if s.left == shape.left and s.top == shape.top and s.shape_type == MSO_SHAPE_TYPE.PICTURE]
+        self.assertEqual(len(pic), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_worksheets.py
+++ b/tests/test_worksheets.py
@@ -168,14 +168,16 @@ class TestProcessWorksheet(unittest.TestCase):
         """Cells starting with %image% should trigger image replacement."""
 
         cell_img = MagicMock()
-        cell_img.value = "%image% file://foo.png"
+        cell_img.value = "%imagesqueeze% file://foo.png"
         cell_img.column_letter = "A"
 
         self.worksheet.iter_cols.return_value = [[cell_img]]
 
         process_worksheet(worksheet=self.worksheet, context=self.context, perm_user=None)
 
-        mock_replace.assert_called_once_with(cell_img, self.worksheet)
+        mock_replace.assert_called_once_with(
+            cell_img, self.worksheet, context=self.context, perm_user=None
+        )
         mock_process_text_list.assert_not_called()
 
 

--- a/tests/test_xlsx_integration.py
+++ b/tests/test_xlsx_integration.py
@@ -271,7 +271,7 @@ class TestXlsxIntegration(unittest.TestCase):
         self.assertEqual(ws_callable["A3"].value, 30.0)  # 10+5=15, 15*2=30
 
     def test_image_cell_integration(self):
-        """A cell starting with %image% should be replaced with a picture."""
+        """A cell starting with %imagesqueeze% should be replaced with a picture."""
 
         from PIL import Image
 
@@ -280,7 +280,7 @@ class TestXlsxIntegration(unittest.TestCase):
         img.save(img_file)
 
         ws = self.wb.create_sheet(title="Images")
-        ws["A1"] = f"%image% file://{img_file}"
+        ws["A1"] = f"%imagesqueeze% file://{img_file}"
         self.wb.save(self.temp_input)
 
         rendered, errors = render_xlsx(


### PR DESCRIPTION
## Summary
- support placeholder URLs in image replacements
- add `%imagesqueeze%` and update `%image%` to preserve aspect ratio
- integrate new behaviour in PPTX/XLSX renderers
- update README and tests

## Testing
- `pytest -q` *(fails: command not found)*