### PR TITLE
Add signal for report generation and enhance report chooser

### DIFF
--- a/template_reports/signals.py
+++ b/template_reports/signals.py
@@ -1,0 +1,5 @@
+from django.dispatch import Signal
+
+# Signal sent when a report is generated and a ReportRun is created.
+# Provides: report_run (the ReportRun instance), context (dict), perm_user (user who triggered generation)
+report_generated = Signal()

--- a/template_reports/templates/admin/choose_report_definition.html
+++ b/template_reports/templates/admin/choose_report_definition.html
@@ -1,6 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 {% block content %}
+  {{ form.media }}            {# loads select2 / autocomplete assets #}
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}


### PR DESCRIPTION
Introduce a signal that triggers upon successful report generation, allowing consumers to create related records. Replace the report chooser widget with an autocomplete feature for improved usability. Additionally, enhance mathematical operations to support lists without failure when encountering square brackets.

Fixes #12