### PR TITLE
Add looping functionality for PowerPoint templates

### DIFF
--- a/docs/Looping in PowerPoint Templates.md
+++ b/docs/Looping in PowerPoint Templates.md
@@ -1,0 +1,56 @@
+# Looping in PowerPoint Templates
+
+In PowerPoint templates, you can use loop directives to repeat slides for each item in a collection. This is useful for creating reports with repetitive sections, such as user profiles, product information, or any other data that follows the same structure for multiple items.
+
+## Basic Loop Syntax
+
+To create a loop in your PowerPoint template:
+
+1. Add a shape with text `%loop variable in collection%` to mark the start of the loop
+2. Add a shape with text `%endloop%` to mark the end of the loop
+3. In the slides between these markers, use `{{ variable }}` to reference the current item
+
+For example, to create slides for each user in a list of users:
+
+```
+%loop user in users%           • On the first slide of the loop
+... slides with {{ user.name }}, {{ user.email }}, etc.
+%endloop%                      • On the last slide of the loop
+```
+
+## How Looping Works
+
+- The slides between the loop start and end (inclusive) will be duplicated for each item in the collection
+- For each duplicate set, the loop variable will be set to the current item in the collection
+- You can reference the loop variable in any placeholders within the duplicated slides
+
+## Example
+
+If your context has:
+
+```python
+context = {
+  "users": [
+    {"name": "Alice", "email": "alice@example.com"},
+    {"name": "Bob", "email": "bob@example.com"}
+  ]
+}
+```
+
+And your template has three slides:
+1. First slide with `%loop user in users%`
+2. Middle slide with `Name: {{ user.name }}, Email: {{ user.email }}`
+3. Last slide with `%endloop%`
+
+The result will be:
+1. First slide with `%loop user in users%`
+2. Middle slide with `Name: Alice, Email: alice@example.com`
+3. Middle slide with `Name: Bob, Email: bob@example.com`
+4. Last slide with `%endloop%`
+
+## Rules and Limitations
+
+- Loops cannot be nested (no loop inside another loop)
+- A slide cannot have both loop start and loop end directives
+- Each loop must have a matching endloop
+- The collection must be iterable (list, tuple, etc.)

--- a/docs/Template Authoring Guide.md
+++ b/docs/Template Authoring Guide.md
@@ -161,7 +161,24 @@ Remember you can use the nested placeholders, so you could always do:
 
 ---
 
-## 9. Best Practices
+## 9. Looping in PowerPoint
+
+In PowerPoint templates, you can use special loop directives to repeat slides for items in a collection:
+
+```
+%loop user in users%           • First slide of loop section
+... Content with {{ user.name }} etc.
+%endloop%                      • Last slide of loop section
+```
+
+Slides between these markers (inclusive) are duplicated for each item in the collection.
+Each duplicate gets the variable (`user` in this example) set to a different item.
+
+See the separate [Looping in PowerPoint Templates.md](./Looping%20in%20PowerPoint%20Templates.md) guide for complete details.
+
+---
+
+## 10. Best Practices
 
 1. **Design first**: Lay out your slide or sheet exactly as you want the final report to look.  
 2. **Use plain text**: Avoid formulas or extra punctuation inside `{{ }}`.  
@@ -181,6 +198,7 @@ Remember you can use the nested placeholders, so you could always do:
 | Uppercase      | `{{ title | upper }}`               | REPORT TITLE                   |
 | Math           | `{{ price * 1.2 }}`                 | 240.00                         |
 | Filter         | `{{ items[type="A"].count }}`       | [count1, count2, …]            |
+| Loop (PPTX)    | `%loop user in users%`              | Repeats slides with user data  |
 | Image          | `%image% https://…/logo.png`        | (embedded logo)                |
 
 With this guide, you’ll be able to build dynamic, data-driven slides and spreadsheets—no code required!

--- a/template_reports/office_renderer/constants.py
+++ b/template_reports/office_renderer/constants.py
@@ -1,0 +1,26 @@
+"""
+Constants used in the template reports system.
+"""
+
+# Loop directive keywords
+LOOP_KEYWORD = "loop"
+IN_KEYWORD = "in"
+ENDLOOP_KEYWORD = "endloop"
+
+# Image directive keywords
+IMAGE_KEYWORD = "image"
+IMAGESQUEEZE_KEYWORD = "imagesqueeze"
+
+# Directive markers
+DIRECTIVE_START = "%"
+DIRECTIVE_END = "%"
+
+# Full directive patterns
+LOOP_START_PATTERN_STR = f"{DIRECTIVE_START}\\s*{LOOP_KEYWORD}\\s+(\\w+)\\s+{IN_KEYWORD}\\s+(.+?)\\s*{DIRECTIVE_END}"
+LOOP_END_PATTERN_STR = f"{DIRECTIVE_START}\\s*{ENDLOOP_KEYWORD}\\s*{DIRECTIVE_END}"
+
+# Image directive patterns
+IMAGE_DIRECTIVES = {
+    f"{DIRECTIVE_START}{IMAGE_KEYWORD}{DIRECTIVE_END}": "fit",
+    f"{DIRECTIVE_START}{IMAGESQUEEZE_KEYWORD}{DIRECTIVE_END}": "squeeze",
+}

--- a/template_reports/office_renderer/images.py
+++ b/template_reports/office_renderer/images.py
@@ -7,13 +7,8 @@ from openpyxl.drawing.image import Image as XLImage
 from PIL import Image as PILImage
 
 from ..templating import process_text
+from .constants import IMAGE_DIRECTIVES
 from .exceptions import ImageError
-
-
-IMAGE_DIRECTIVES = {
-    "%image%": "fit",
-    "%imagesqueeze%": "squeeze",
-}
 
 
 def extract_image_directive(text: str | None) -> tuple[str | None, str | None]:

--- a/template_reports/office_renderer/loops.py
+++ b/template_reports/office_renderer/loops.py
@@ -1,0 +1,307 @@
+"""
+Functions to handle loop functionality in PPTX templates.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Iterable, Optional, Any
+
+from ..templating import resolve_tag
+from .constants import (
+    LOOP_START_PATTERN_STR,
+    LOOP_END_PATTERN_STR,
+)
+from .pptx_utils import duplicate_slide, remove_shape
+
+if TYPE_CHECKING:
+    from pptx.presentation import Presentation
+
+# Patterns for loop directives
+LOOP_START_PATTERN = re.compile(LOOP_START_PATTERN_STR)
+LOOP_END_PATTERN = re.compile(LOOP_END_PATTERN_STR)
+
+
+def extract_loop_directive(text: str | None) -> tuple[str | None, str | None]:
+    """Return (variable, collection) if *text* contains a loop directive."""
+    if not text:
+        return None, None
+
+    match = LOOP_START_PATTERN.search(text.strip())
+    if match:
+        variable = match.group(1)
+        collection = match.group(2)
+        return variable, collection
+
+    return None, None
+
+
+def is_loop_start(shape) -> bool:
+    """Return True if the shape text indicates a loop start."""
+    if not hasattr(shape, "text_frame") or not hasattr(shape.text_frame, "text"):
+        return False
+
+    variable, collection = extract_loop_directive(shape.text_frame.text)
+    return variable is not None and collection is not None
+
+
+def is_loop_end(shape) -> bool:
+    """Return True if the shape text indicates a loop end."""
+    if not hasattr(shape, "text_frame") or not hasattr(shape.text_frame, "text"):
+        return False
+
+    text = shape.text_frame.text
+    if not text:
+        return False
+
+    return LOOP_END_PATTERN.search(text.strip()) is not None
+
+
+def get_collection_from_collection_tag(
+    collection_tag: str,
+    context: dict,
+    perm_user,
+) -> tuple[Optional[Iterable[Any]], Optional[str]]:
+    """
+    Given a collection tag, resolve it to a collection in the context.
+    This function is a placeholder and should be implemented based on your context resolution logic.
+    """
+    # Get the collection from the context using resolve_tag
+    try:
+        collection = resolve_tag(collection_tag, context, perm_user)
+    except Exception as e:
+        return (
+            None,
+            f"Failed to resolve collection '{collection_tag}': {str(e)}",
+        )
+
+    # No collection
+    if collection is None:
+        return None, f"Collection '{collection_tag}' not found in context"
+
+    # Ensure the collection is iterable (force evaluation of any lazy iterables)
+    try:
+        collection = list(collection)
+    except TypeError:
+        return None, f"'{collection_tag}' is not a collection of things"
+
+    # For empty or nonexistent collections
+    if not collection:
+        return None, f"Collection '{collection_tag}' is empty"
+
+    return collection, None
+
+
+def process_loops(prs: Presentation, context, perm_user, errors):
+    """
+    Process loops in the presentation:
+    - Identify loop sections (slides between %loop var in collection% and %endloop%)
+    - For each item in the collection, create a mapping between loop slides and variables
+    - Return a list of slides to process with their context info
+    """
+
+    # First pass: identify loop sections and collect info about them
+    slide_sections = []
+    in_loop = False
+    loop_variable_name = None
+    loop_collection = None
+    loop_slides = []
+
+    for i, slide in enumerate(prs.slides):
+        # Track whether this slide has loop directives
+        has_loop_start = False
+        has_loop_end = False
+        loop_start_shapes = []
+        loop_end_shapes = []
+
+        for shape in slide.shapes:
+            # Check for loop start
+            if is_loop_start(shape):
+                # Store the shape, but delete it from the slide
+                loop_start_shapes.append(shape)
+                remove_shape(shape)
+
+                # Quit if multiple loop start directives on the same slide
+                if len(loop_start_shapes) > 1:
+                    errors.append(
+                        f"Error on slide {i + 1}: Multiple loop start directives on same slide"
+                    )
+                    return []
+
+                # Get the loop variable and collection data
+                loop_variable_name, collection_tag = extract_loop_directive(
+                    shape.text_frame.text
+                )
+                if loop_variable_name and collection_tag:
+                    has_loop_start = True
+                    loop_collection, error = get_collection_from_collection_tag(
+                        collection_tag, context, perm_user
+                    )
+                    if error:
+                        errors.append(f"Error on slide {i + 1}: {error}")
+                        return []
+                else:
+                    errors.append(f"Error on slide {i + 1}: Invalid loop start directive")
+                    return []
+
+            # Check for loop end
+            if is_loop_end(shape):
+                # Store the shape, but delete it from the slide
+                loop_end_shapes.append(shape)
+                remove_shape(shape)
+
+                # Quit if multiple loop end directives on the same slide
+                if len(loop_end_shapes) > 1:
+                    errors.append(
+                        f"Error on slide {i + 1}: Multiple loop end directives on same slide"
+                    )
+                    return []
+
+                if not in_loop and not has_loop_start:
+                    errors.append(
+                        f"Error on slide {i + 1}: %endloop% without a matching loop start"
+                    )
+                has_loop_end = True
+
+        # Handle loop start
+        if has_loop_start:
+            if in_loop:
+                errors.append(f"Error on slide {i + 1}: Nested loops are not supported")
+                return []
+
+            in_loop = True
+
+        # Handle if in loop
+        if in_loop:
+
+            # Store slides, either in loop or not
+            loop_slides.append(slide)
+
+            # Handle loop end
+            if has_loop_end:
+                # Quit if loop end directives there are on the slide
+                loop_end_count = sum(1 for shape in slide.shapes if is_loop_end(shape))
+                if loop_end_count > 1:
+                    errors.append(
+                        f"Error on slide {i + 1}: Multiple loop end directives on same slide"
+                    )
+                    return []
+
+                slide_sections.append(
+                    {
+                        "slides": loop_slides,
+                        "loop_variable_name": loop_variable_name,
+                        "loop_collection": loop_collection,
+                    }
+                )
+
+                # Reset loop state
+                in_loop = False
+                loop_variable_name = None
+                loop_collection = None
+                loop_slides = []
+
+        # Non-loop slides
+        else:
+            slide_sections.append(
+                {
+                    "slides": [slide],
+                }
+            )
+
+        # # Handle loop slides
+        # if in_loop:
+        #     # For each item in the collection, process each slide
+        #     assert collection
+        #     for loop_item in collection:
+        #         # Add the loop variable to the context for this slide
+        #         extra_context = {loop_variable_name: loop_item}
+        #         for j in range(section["start_index"], section["end_index"] + 1):
+        #             # Duplicate the slide scenarios
+        #             new_slide = duplicate_slide(prs, j)
+        #             # Store the new slide in the list
+        #             slides_to_process.append(
+        #                 {
+        #                     "slide": new_slide,
+        #                     "slide_number": current_slide_number,
+        #                     "extra_context": extra_context,
+        #                 }
+        #             )
+        #             current_slide_number += 1
+
+        # # Handle non-loop slides
+        # else:
+        #     slides_to_process.append(
+        #         {
+        #             "slide": slide,
+        #             "slide_number": current_slide_number,
+        #         }
+        #     )
+        #     current_slide_number += 1
+
+    # Check for unclosed loops
+    if in_loop:
+        errors.append(f"Error: Loop started but never closed with %endloop%")
+        return []  # Short-circuit when unclosed loop found
+
+    # Keep track of which slides are part of loops to avoid duplicating them
+    # loop_slide_indices = set()
+    # for section in slide_sections:
+    #     for i in range(section["start_index"], section["end_index"] + 1):
+    #         loop_slide_indices.add(i)
+
+    # Prepare slides to process
+    slides_to_process = []
+    current_slide_number = 1
+
+    # Create the slide structure (incl duplication and extra loop context)
+    for section in slide_sections:
+        loop_variable_name = section.get("loop_variable_name", None)
+        loop_collection = section.get("loop_collection", None)
+        slides = section.get("slides")
+
+        # Not in loop
+        if not loop_variable_name:
+            for slide in slides:
+                slides_to_process.append(
+                    {
+                        "slide": slide,
+                        "slide_number": current_slide_number,
+                    }
+                )
+                current_slide_number += 1
+
+        # In loop
+        else:
+            assert loop_collection is not None
+
+            # For each item in the collection, process each slide
+            loop_count = len(loop_collection)
+            for i, loop_item in enumerate(loop_collection):
+                # Add the loop variable to the context for this slide
+                extra_context = {
+                    section["loop_variable_name"]: loop_item,
+                    "loop_count": loop_count,
+                }
+                for slide in slides:
+                    # Duplicate the slide, or (if this is first loop item) use the original
+                    if i == 0:
+                        new_slide = slide
+                    else:
+                        # Current slide number is 1-indexed
+                        new_slide_index = current_slide_number - 1
+                        new_slide = duplicate_slide(prs, slide, new_slide_index)
+                    # Store the new slide in the list
+                    slides_to_process.append(
+                        {
+                            "slide": new_slide,
+                            "slide_number": current_slide_number,
+                            "extra_context": {
+                                **extra_context,
+                                "loop_number": i + 1,
+                            },
+                        }
+                    )
+                    current_slide_number += 1
+
+    return slides_to_process

--- a/template_reports/office_renderer/pptx.py
+++ b/template_reports/office_renderer/pptx.py
@@ -1,12 +1,40 @@
 from pptx import Presentation
-
 from .charts import process_chart
 from .images import (
     replace_shape_with_image,
     should_replace_shape_with_image,
 )
+from .loops import (
+    is_loop_end,
+    is_loop_start,
+    process_loops,
+    LOOP_START_PATTERN,
+    LOOP_END_PATTERN,
+)
 from .paragraphs import process_paragraph
+from .pptx_utils import remove_shape
 from .tables import process_table_cell
+
+
+def clear_loop_directives(prs):
+    """
+    Clear the text of all shapes that contain loop directives.
+
+    Args:
+        prs: The Presentation object
+    """
+    for slide in prs.slides:
+        for shape in slide.shapes:
+            if hasattr(shape, "text_frame") and hasattr(shape.text_frame, "text"):
+                text = shape.text_frame.text.strip()
+                if LOOP_START_PATTERN.search(text) or LOOP_END_PATTERN.search(text):
+                    # Clear text at paragraph level to handle formatting
+                    for paragraph in shape.text_frame.paragraphs:
+                        if paragraph.runs:
+                            for run in paragraph.runs:
+                                run.text = ""
+                        else:
+                            paragraph.text = ""
 
 
 def render_pptx(template, context: dict, output, perm_user):
@@ -23,69 +51,36 @@ def render_pptx(template, context: dict, output, perm_user):
 
     errors = []
 
-    for i, slide in enumerate(prs.slides):
-        # Add extra context per slide.
-        slide_number = i + 1
+    # Process loops first - identify loop sections and duplicate slides
+    slides_to_process = process_loops(prs, context, perm_user, errors)
+
+    # Process all slides including duplicated ones from loops
+    for slide_info in slides_to_process:
+        slide = slide_info["slide"]
+        slide_number = slide_info.get("slide_number", 0)
+        extra_context = slide_info.get("extra_context", {})
+
+        # Create slide context (include `extra_context`, which is where loop variables are)
         slide_context = {
             **context,
+            **extra_context,
             "slide_number": slide_number,
         }
 
+        # Add loop variable to context if present
+        if "loop_var" in slide_info and "loop_item" in slide_info:
+            slide_context[slide_info["loop_var"]] = slide_info["loop_item"]
+
+        # Process the slide's shapes
         for shape in slide.shapes:
-            # Check if this shape should be replaced with an image.
-            if should_replace_shape_with_image(shape):
-                try:
-                    replace_shape_with_image(
-                        shape,
-                        slide,
-                        context=slide_context,
-                        perm_user=perm_user,
-                    )
-                except Exception as e:
-                    errors.append(
-                        f"Error processing image (slide {slide_number}): {e}"
-                    )
-                # Skip further processing for this shape
+            # Skip loop directive shapes - we'll clear them later
+            if is_loop_start(shape) or is_loop_end(shape):
                 continue
 
-            # 1) Process text frames (non-table).
-            if hasattr(shape, "text_frame"):
-                for paragraph in shape.text_frame.paragraphs:
-                    # Merge any placeholders that are split across multiple runs.
-                    try:
-                        process_paragraph(
-                            paragraph=paragraph,
-                            context=slide_context,
-                            perm_user=perm_user,
-                            mode="normal",  # for text frames
-                        )
-                    except Exception as e:
-                        errors.append(f"Error in paragraph (slide {slide_number}): {e}")
-            # 2) Process tables.
-            if getattr(shape, "has_table", False):
-                for row in shape.table.rows:
-                    for cell in row.cells:
-                        try:
-                            process_table_cell(
-                                cell=cell,
-                                context=slide_context,
-                                perm_user=perm_user,
-                            )
-                        except Exception as e:
-                            errors.append(
-                                f"Error in table cell (slide {slide_number}): {e}"
-                            )
-            # 3) Process chart spreadsheets.
-            if getattr(shape, "has_chart", False):
-                try:
-                    process_chart(
-                        chart=shape.chart,
-                        context=slide_context,
-                        perm_user=perm_user,
-                    )
-                except Exception as e:
-                    errors.append(f"Error in chart (slide {slide_number}): {e}")
-
+            # Process the shape content
+            process_shape_content(
+                shape, slide, slide_context, slide_number, perm_user, errors
+            )
 
     if errors:
         print("Rendering aborted due to the following errors:")
@@ -102,3 +97,63 @@ def render_pptx(template, context: dict, output, perm_user):
         output.seek(0)
 
     return output, None
+
+
+def process_shape_content(shape, slide, context, slide_number, perm_user, errors):
+    """Process the content of a shape based on its type."""
+    # 1) Check if this shape should be replaced with an image.
+    if should_replace_shape_with_image(shape):
+        try:
+            replace_shape_with_image(
+                shape,
+                slide,
+                context=context,
+                perm_user=perm_user,
+            )
+        except Exception as e:
+            errors.append(f"Error processing image (slide {slide_number}): {e}")
+        # Skip further processing for this shape.
+        return
+
+    # 2) Check if this shape should be removed (because it's a loop directive).
+    if is_loop_start(shape) or is_loop_end(shape):
+        remove_shape(shape)
+        return
+
+    # 3) Process text frames (non-table).
+    if hasattr(shape, "text_frame"):
+        for paragraph in shape.text_frame.paragraphs:
+            # Merge any placeholders that are split across multiple runs.
+            try:
+                process_paragraph(
+                    paragraph=paragraph,
+                    context=context,
+                    perm_user=perm_user,
+                    mode="normal",  # for text frames
+                )
+            except Exception as e:
+                errors.append(f"Error in paragraph (slide {slide_number}): {e}")
+
+    # 4) Process tables.
+    if getattr(shape, "has_table", False):
+        for row in shape.table.rows:
+            for cell in row.cells:
+                try:
+                    process_table_cell(
+                        cell=cell,
+                        context=context,
+                        perm_user=perm_user,
+                    )
+                except Exception as e:
+                    errors.append(f"Error in table cell (slide {slide_number}): {e}")
+
+    # 5) Process chart spreadsheets.
+    if getattr(shape, "has_chart", False):
+        try:
+            process_chart(
+                chart=shape.chart,
+                context=context,
+                perm_user=perm_user,
+            )
+        except Exception as e:
+            errors.append(f"Error in chart (slide {slide_number}): {e}")

--- a/template_reports/office_renderer/pptx_utils.py
+++ b/template_reports/office_renderer/pptx_utils.py
@@ -1,0 +1,78 @@
+"""
+Utility functions for PPTX manipulation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from copy import deepcopy
+
+if TYPE_CHECKING:
+    from pptx.presentation import Presentation
+    from pptx.slide import Slide
+    from pptx.shapes.base import BaseShape
+
+
+def duplicate_slide(
+    pres: Presentation,
+    slide: Slide,
+    index: Optional[int] = None,
+) -> Slide:
+    """
+    Create a duplicate of the given slide and return the new slide.
+
+    This function duplicates a slide by:
+    1. Getting the source slide
+    2. Creating a new blank slide
+    3. Copying all shapes from source to destination
+
+    Args:
+        pres: The Presentation object
+        slide: The slide object to duplicate
+
+    Returns:
+        The newly created slide object
+    """
+    # (1) Create new slide (always appended to the end for now)
+    new_slide = pres.slides.add_slide(slide.slide_layout)
+
+    #  (2) Calculate where the duplicate should live
+    sld_ids = pres.slides._sldIdLst
+    src_idx = pres.slides.index(slide)  # position of original
+    dest_idx = (
+        len(sld_ids) + index
+        if index is not None and index < 0  # negative slice logic
+        else index if index is not None else src_idx + 1
+    )
+    dest_idx = max(0, min(dest_idx, len(sld_ids) - 1))  # clamp to bounds
+
+    # (3) Move the slide-id element to that position
+    new_sld_id = sld_ids[-1]  # id for slide we just appended
+    sld_ids.remove(new_sld_id)
+    sld_ids.insert(dest_idx, new_sld_id)
+    # Delete all the shapes in the new slide
+    for shape in new_slide.shapes:
+        remove_shape(shape)
+
+    # Deep-copy all shapes from the source slide to the new slide
+    for shape in slide.shapes:
+        new_el = deepcopy(shape.element)
+        new_slide.shapes._spTree.insert_element_before(new_el, "p:extLst")
+
+    return new_slide
+
+
+def remove_shape(shape: BaseShape):
+    """
+    Remove a shape from a slide.
+
+    This function removes a shape by removing its XML element from the slide's shape tree.
+
+    Args:
+        slide: The slide object containing the shape
+        shape: The shape object to remove
+    """
+    parent = shape.element.getparent()
+    if parent is not None:
+        parent.remove(shape.element)

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -1,0 +1,420 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+from pptx.util import Inches
+
+from template_reports.office_renderer.loops import (
+    extract_loop_directive,
+    is_loop_end,
+    is_loop_start,
+    process_loops,
+    LOOP_START_PATTERN,
+    LOOP_END_PATTERN,
+)
+
+
+class TestLoopDirectives(unittest.TestCase):
+    def setUp(self):
+        self.prs = Presentation()
+        self.slide = self.prs.slides.add_slide(self.prs.slide_layouts[5])
+        self.textbox = self.slide.shapes.add_textbox(
+            Inches(1), Inches(1), Inches(2), Inches(2)
+        )
+
+    def test_extract_loop_directive(self):
+        """Test the extraction of loop variable and collection from directive."""
+        # Valid loop directive
+        self.textbox.text_frame.text = "%loop user in users%"
+        variable, collection = extract_loop_directive(self.textbox.text_frame.text)
+        self.assertEqual(variable, "user")
+        self.assertEqual(collection, "users")
+
+        # Valid loop directive with spaces
+        self.textbox.text_frame.text = "% loop user in users %"
+        variable, collection = extract_loop_directive(self.textbox.text_frame.text)
+        self.assertEqual(variable, "user")
+        self.assertEqual(collection, "users")
+
+        # Valid loop directive with dot notation
+        self.textbox.text_frame.text = "%loop user in program.users%"
+        variable, collection = extract_loop_directive(self.textbox.text_frame.text)
+        self.assertEqual(variable, "user")
+        self.assertEqual(collection, "program.users")
+
+        # Valid loop directive with dot notation and filtering
+        self.textbox.text_frame.text = "%loop user in program.users[is_active=True]%"
+        variable, collection = extract_loop_directive(self.textbox.text_frame.text)
+        self.assertEqual(variable, "user")
+        self.assertEqual(collection, "program.users[is_active=True]")
+
+        # Invalid loop directive
+        self.textbox.text_frame.text = "Not a loop directive"
+        variable, collection = extract_loop_directive(self.textbox.text_frame.text)
+        self.assertIsNone(variable)
+        self.assertIsNone(collection)
+
+        # Empty text
+        variable, collection = extract_loop_directive(None)
+        self.assertIsNone(variable)
+        self.assertIsNone(collection)
+
+    def test_is_loop_start(self):
+        """Test the detection of loop start directive."""
+        # Valid loop start
+        self.textbox.text_frame.text = "%loop user in users%"
+        self.assertTrue(is_loop_start(self.textbox))
+
+        # Not a loop start
+        self.textbox.text_frame.text = "Not a loop start"
+        self.assertFalse(is_loop_start(self.textbox))
+
+        # Shape has no text_frame - use proper mocking
+        shape_without_text_frame = MagicMock(spec=[])  # No text_frame attribute
+        self.assertFalse(is_loop_start(shape_without_text_frame))
+
+        # Text frame has no text attribute - use proper mocking
+        shape_with_empty_text_frame = MagicMock()
+        text_frame_without_text = MagicMock(spec=[])  # No text attribute
+        shape_with_empty_text_frame.text_frame = text_frame_without_text
+        self.assertFalse(is_loop_start(shape_with_empty_text_frame))
+
+    def test_is_loop_end(self):
+        """Test the detection of loop end directive."""
+        # Valid loop end
+        self.textbox.text_frame.text = "%endloop%"
+        self.assertTrue(is_loop_end(self.textbox))
+
+        # Valid loop end with spaces
+        self.textbox.text_frame.text = "% endloop %"
+        self.assertTrue(is_loop_end(self.textbox))
+
+        # Not a loop end
+        self.textbox.text_frame.text = "Not a loop end"
+        self.assertFalse(is_loop_end(self.textbox))
+
+        # Shape has no text_frame - use proper mocking
+        shape_without_text_frame = MagicMock(spec=[])  # No text_frame attribute
+        self.assertFalse(is_loop_end(shape_without_text_frame))
+
+        # Text frame has no text attribute - use proper mocking
+        shape_with_empty_text_frame = MagicMock()
+        text_frame_without_text = MagicMock(spec=[])  # No text attribute
+        shape_with_empty_text_frame.text_frame = text_frame_without_text
+        self.assertFalse(is_loop_end(shape_with_empty_text_frame))
+
+    def test_regex_patterns(self):
+        """Test that the regex patterns handle spaces correctly."""
+        # Test LOOP_START_PATTERN
+        self.assertIsNotNone(LOOP_START_PATTERN.search("%loop user in users%"))
+        self.assertIsNotNone(LOOP_START_PATTERN.search("% loop user in users %"))
+        self.assertIsNotNone(LOOP_START_PATTERN.search("%  loop  user  in  users  %"))
+
+        # Test LOOP_END_PATTERN
+        self.assertIsNotNone(LOOP_END_PATTERN.search("%endloop%"))
+        self.assertIsNotNone(LOOP_END_PATTERN.search("% endloop %"))
+        self.assertIsNotNone(LOOP_END_PATTERN.search("%  endloop  %"))
+
+
+class TestLoopProcessing(unittest.TestCase):
+    def setUp(self):
+        self.context = {
+            "users": [
+                {"name": "Alice", "email": "alice@example.com"},
+                {"name": "Bob", "email": "bob@example.com"},
+            ]
+        }
+
+        # Create more complex context for testing dot notation
+        self.complex_context = {
+            "program": {
+                "users": [
+                    {"name": "Alice", "email": "alice@example.com", "is_active": True},
+                    {"name": "Bob", "email": "bob@example.com", "is_active": True},
+                    {
+                        "name": "Charlie",
+                        "email": "charlie@example.com",
+                        "is_active": False,
+                    },
+                ]
+            }
+        }
+
+        # Create a presentation and errors list for testing
+        self.prs = Presentation()
+        self.errors = []
+
+    def test_process_loops_slide_numbers(self):
+        """Test that process_loops correctly numbers slides."""
+        # Create a presentation with 5 slides:
+        # Slide 1: Normal slide
+        # Slide 2: Loop start
+        # Slide 3: Content inside loop
+        # Slide 4: Loop end
+        # Slide 5: Normal slide
+
+        # Add all slides
+        slides = []
+        for i in range(5):
+            slides.append(self.prs.slides.add_slide(self.prs.slide_layouts[5]))
+
+        # Add loop start to slide 2
+        loop_start = slides[1].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(2), Inches(0.5)
+        )
+        loop_start.text_frame.text = "%loop user in users%"
+
+        # Add loop end to slide 4
+        loop_end = slides[3].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(2), Inches(0.5)
+        )
+        loop_end.text_frame.text = "%endloop%"
+
+        # Process loops
+        result = process_loops(self.prs, self.context, None, self.errors)
+
+        # We should have:
+        # - Slide 1 (normal) with slide_number 1
+        # - Slides 2-4 (loop) repeated twice (2 users), with slide_numbers 2-7
+        # - Slide 5 (normal) with slide_number 8
+
+        # Check total number of slides to process
+        self.assertEqual(len(result), 8)
+
+        # Check slide numbers
+        self.assertEqual(result[0]["slide_number"], 1)  # First normal slide
+
+        # First loop iteration (3 slides)
+        self.assertEqual(result[1]["slide_number"], 2)
+        self.assertEqual(result[2]["slide_number"], 3)
+        self.assertEqual(result[3]["slide_number"], 4)
+
+        # Second loop iteration (3 slides)
+        self.assertEqual(result[4]["slide_number"], 5)
+        self.assertEqual(result[5]["slide_number"], 6)
+        self.assertEqual(result[6]["slide_number"], 7)
+
+        # Last normal slide
+        self.assertEqual(result[7]["slide_number"], 8)
+
+    def test_process_loops_dot_notation(self):
+        """Test process_loops with dot notation for the collection."""
+        # Create a presentation with 3 slides (start, content, end)
+        slides = []
+        for i in range(3):
+            slides.append(self.prs.slides.add_slide(self.prs.slide_layouts[5]))
+
+        # Add loop with dot notation to first slide
+        loop_start = slides[0].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(0.5)
+        )
+        loop_start.text_frame.text = "%loop user in program.users%"
+
+        # Add loop end to last slide
+        loop_end = slides[2].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(0.5)
+        )
+        loop_end.text_frame.text = "%endloop%"
+
+        # Process loops
+        result = process_loops(self.prs, self.complex_context, None, self.errors)
+
+        # We should have 9 slides (3 slides × 3 users)
+        self.assertEqual(len(result), 9)
+        self.assertEqual(len(self.errors), 0)
+
+    def test_process_loops_with_filtering(self):
+        """Test process_loops with filtering in the collection."""
+        # Create a presentation with 3 slides (start, content, end)
+        slides = []
+        for i in range(3):
+            slides.append(self.prs.slides.add_slide(self.prs.slide_layouts[5]))
+
+        # Add loop with filtering to first slide
+        loop_start = slides[0].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(4), Inches(0.5)
+        )
+        loop_start.text_frame.text = "%loop user in program.users[is_active=True]%"
+
+        # Add loop end to last slide
+        loop_end = slides[2].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(0.5)
+        )
+        loop_end.text_frame.text = "%endloop%"
+
+        # Process loops
+        result = process_loops(self.prs, self.complex_context, None, self.errors)
+
+        # We should have 6 slides (3 slides × 2 active users)
+        self.assertEqual(len(result), 6)
+        self.assertEqual(len(self.errors), 0)
+
+    def test_process_loops_with_nonexistent_collection(self):
+        """Test process_loops with a nonexistent collection."""
+        # Create a presentation with 3 slides (start, content, end)
+        slides = []
+        for i in range(3):
+            slides.append(self.prs.slides.add_slide(self.prs.slide_layouts[5]))
+
+        # Add loop with nonexistent collection
+        loop_start = slides[0].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(4), Inches(0.5)
+        )
+        loop_start.text_frame.text = "%loop user in nonexistent%"
+
+        # Add loop end to last slide
+        loop_end = slides[2].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(0.5)
+        )
+        loop_end.text_frame.text = "%endloop%"
+
+        # Process loops
+        result = process_loops(self.prs, self.complex_context, None, self.errors)
+
+        # We should have an error but non-loop slides should be processed
+        self.assertTrue(any("nonexistent" in error for error in self.errors))
+
+    def test_process_loops_with_multiple_directives_on_same_slide(self):
+        """Test process_loops with multiple loop directives on the same slide."""
+        # Create a presentation with 3 slides
+        slides = []
+        for i in range(3):
+            slides.append(self.prs.slides.add_slide(self.prs.slide_layouts[5]))
+
+        # Add multiple loop starts to first slide
+        loop_start1 = slides[0].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(0.5)
+        )
+        loop_start1.text_frame.text = "%loop user in users%"
+
+        loop_start2 = slides[0].shapes.add_textbox(
+            Inches(1), Inches(2), Inches(3), Inches(0.5)
+        )
+        loop_start2.text_frame.text = "%loop item in items%"
+
+        # Add loop end to last slide
+        loop_end = slides[2].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(0.5)
+        )
+        loop_end.text_frame.text = "%endloop%"
+
+        # Process loops
+        result = process_loops(self.prs, self.context, None, self.errors)
+
+        # We should get errors about multiple loop starts
+        self.assertTrue(
+            any(
+                "Multiple loop start directives on same slide" in error
+                for error in self.errors
+            )
+        )
+
+    def test_process_loops_with_both_start_and_end_on_same_slide(self):
+        """Test process_loops with both start and end directives on the same slide."""
+        # Create a presentation with 3 slides
+        slides = []
+        for i in range(3):
+            slides.append(self.prs.slides.add_slide(self.prs.slide_layouts[5]))
+
+        # Add both start and end to first slide
+        loop_start = slides[0].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(0.5)
+        )
+        loop_start.text_frame.text = "%loop user in users%"
+
+        loop_end = slides[0].shapes.add_textbox(
+            Inches(1), Inches(2), Inches(3), Inches(0.5)
+        )
+        loop_end.text_frame.text = "%endloop%"
+
+        # Process loops
+        result = process_loops(self.prs, self.context, None, self.errors)
+
+        # We should NOT get an error about both directives on same slide
+        self.assertEqual(len(self.errors), 0)
+
+    def test_process_loops_with_unclosed_loop(self):
+        """Test process_loops with an unclosed loop."""
+        # Create a presentation with 3 slides
+        slides = []
+        for i in range(3):
+            slides.append(self.prs.slides.add_slide(self.prs.slide_layouts[5]))
+
+        # Add loop start but no end
+        loop_start = slides[0].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(0.5)
+        )
+        loop_start.text_frame.text = "%loop user in users%"
+
+        # Process loops
+        result = process_loops(self.prs, self.context, None, self.errors)
+
+        # We should get an error about unclosed loop
+        self.assertTrue(
+            any("Loop started but never closed" in error for error in self.errors)
+        )
+
+    def test_process_loops_with_end_without_start(self):
+        """Test process_loops with an end directive without a matching start."""
+        # Create a presentation with 3 slides
+        slides = []
+        for i in range(3):
+            slides.append(self.prs.slides.add_slide(self.prs.slide_layouts[5]))
+
+        # Add loop end without start
+        loop_end = slides[1].shapes.add_textbox(
+            Inches(1), Inches(1), Inches(3), Inches(0.5)
+        )
+        loop_end.text_frame.text = "%endloop%"
+
+        # Process loops
+        result = process_loops(self.prs, self.context, None, self.errors)
+
+        # We should get an error about endloop without matching start
+        self.assertTrue(
+            any("without a matching loop start" in error for error in self.errors)
+        )
+
+    @patch("template_reports.office_renderer.pptx.process_loops")
+    @patch("template_reports.office_renderer.pptx.Presentation")
+    def test_process_loops_called(self, mock_presentation, mock_process_loops):
+        """Test that process_loops is called from render_pptx."""
+        from template_reports.office_renderer.pptx import render_pptx
+
+        # Prepare mock return value for process_loops
+        mock_process_loops.return_value = []
+
+        # Setup mock for Presentation
+        mock_prs = MagicMock()
+        mock_presentation.return_value = mock_prs
+
+        # Call render_pptx with a string template path
+        render_pptx("template.pptx", {}, "output.pptx", None)
+
+        # Verify process_loops was called
+        mock_process_loops.assert_called_once()
+
+    def test_extract_loop_directive_integration(self):
+        """Test extract_loop_directive directly."""
+        # Valid loop
+        directive = "%loop user in users%"
+        variable, collection = extract_loop_directive(directive)
+        self.assertEqual(variable, "user")
+        self.assertEqual(collection, "users")
+
+        # Invalid format
+        directive = "%loop invalid directive%"
+        variable, collection = extract_loop_directive(directive)
+        self.assertIsNone(variable)
+        self.assertIsNone(collection)
+
+        # Empty
+        directive = ""
+        variable, collection = extract_loop_directive(directive)
+        self.assertIsNone(variable)
+        self.assertIsNone(collection)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_paragraphs.py
+++ b/tests/test_paragraphs.py
@@ -1,0 +1,95 @@
+import unittest
+from template_reports.office_renderer.paragraphs import (
+    merge_split_placeholders,
+    UnterminatedTagException,
+)
+
+
+class DummyRun:
+    def __init__(self, text=""):
+        self.text = text
+        self._r = self  # minimal stub for removal
+
+
+class DummyParagraph:
+    def __init__(self, runs=None):
+        self.runs = runs or []
+        self._p = self  # minimal stub for removal
+
+    @property
+    def text(self):
+        return "".join(run.text for run in self.runs)
+
+    def remove(self, run):
+        self.runs.remove(run)
+
+
+class TestMergeSplitPlaceholders(unittest.TestCase):
+    def test_merge_placeholder_across_runs(self):
+        # {{ in one run, }} in another
+        para = DummyParagraph(
+            [
+                DummyRun("Hello "),
+                DummyRun("{{ name"),
+                DummyRun(" }}!"),
+            ]
+        )
+        # Patch _p.remove to DummyParagraph.remove
+        para._p = para
+        for run in para.runs:
+            run._r = run
+        merge_split_placeholders(para)
+        self.assertEqual(para.text, "Hello {{ name }}!")
+        self.assertEqual(len(para.runs), 2)  # merged into one, plus 'Hello '
+        self.assertEqual(para.runs[1].text, "{{ name }}!")
+
+    def test_merge_multiple_placeholders_across_runs(self):
+        para = DummyParagraph(
+            [
+                DummyRun("{{ foo"),
+                DummyRun(" }} and "),
+                DummyRun("{{ bar"),
+                DummyRun(" }}"),
+            ]
+        )
+        para._p = para
+        for run in para.runs:
+            run._r = run
+        merge_split_placeholders(para)
+        self.assertEqual(para.text, "{{ foo }} and {{ bar }}")
+        self.assertEqual(len(para.runs), 2)
+        self.assertEqual(para.runs[0].text, "{{ foo }} and ")
+        self.assertEqual(para.runs[1].text, "{{ bar }}")
+
+    def test_merge_multiple_placeholders_per_run(self):
+        para = DummyParagraph(
+            [
+                DummyRun("{{ foo }} and {{ "),
+                DummyRun("bar"),
+                DummyRun(" }}"),
+            ]
+        )
+        para._p = para
+        for run in para.runs:
+            run._r = run
+        merge_split_placeholders(para)
+        self.assertEqual(para.text, "{{ foo }} and {{ bar }}")
+        self.assertEqual(len(para.runs), 1)
+        self.assertEqual(para.runs[0].text, "{{ foo }} and {{ bar }}")
+
+    def test_unterminated_tag_raises(self):
+        para = DummyParagraph(
+            [
+                DummyRun("Hello {{ name"),
+                DummyRun(" is here"),
+            ]
+        )
+        para._p = para
+        for run in para.runs:
+            run._r = run
+        with self.assertRaises(UnterminatedTagException):
+            merge_split_placeholders(para)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pptx_loop_integration.py
+++ b/tests/test_pptx_loop_integration.py
@@ -1,0 +1,225 @@
+import os
+import io
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+from pptx import Presentation
+from pptx.util import Inches
+
+from template_reports.office_renderer import render_pptx
+
+
+class TestPptxIntegrationLoops(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary file for the PPTX
+        self.temp_pptx = tempfile.mktemp(suffix=".pptx")
+        self.output_pptx = tempfile.mktemp(suffix=".pptx")
+
+        # Create a presentation with loop directive
+        self.prs = Presentation()
+
+        # Create slides for the loop
+        self.slide1 = self.prs.slides.add_slide(self.prs.slide_layouts[5])
+        self.slide2 = self.prs.slides.add_slide(self.prs.slide_layouts[5])
+        self.slide3 = self.prs.slides.add_slide(self.prs.slide_layouts[5])
+
+        # Add loop start shape to slide 1
+        loop_start = self.slide1.shapes.add_textbox(
+            Inches(1), Inches(1), Inches(2), Inches(0.5)
+        )
+        loop_start.text_frame.text = "%loop user in users%"
+
+        # Add content shape to slide 2
+        user_info = self.slide2.shapes.add_textbox(
+            Inches(1), Inches(2), Inches(4), Inches(1)
+        )
+        user_info.text_frame.text = "Name: {{ user.name }}, Email: {{ user.email }}"
+
+        # Add loop end shape to slide 3
+        loop_end = self.slide3.shapes.add_textbox(
+            Inches(1), Inches(1), Inches(2), Inches(0.5)
+        )
+        loop_end.text_frame.text = "%endloop%"
+
+        # Save the presentation
+        self.prs.save(self.temp_pptx)
+
+        # Prepare the context
+        self.context = {
+            "users": [
+                {"name": "Alice", "email": "alice@example.com"},
+                {"name": "Bob", "email": "bob@example.com"},
+                {"name": "Charlie", "email": "charlie@example.com"},
+            ]
+        }
+
+    def tearDown(self):
+        # Clean up temporary files
+        for temp_file in [self.temp_pptx, self.output_pptx]:
+            if os.path.exists(temp_file):
+                os.remove(temp_file)
+
+    @patch("template_reports.office_renderer.pptx.Presentation")
+    def test_process_loops_integration(self, mock_presentation):
+        """Test the integration of loop processing with minimal mocking."""
+        from template_reports.office_renderer.loops import process_loops
+
+        context = {"users": ["Alice", "Bob", "Charlie"]}
+        errors = []
+
+        prs = MagicMock()
+        slides_list = []
+
+        for i in range(3):
+            slide = MagicMock()
+            shapes = []
+
+            if i == 0:  # First slide with loop start
+                shape = MagicMock()
+                shape.text_frame.text = "%loop user in users%"
+                shapes.append(shape)
+            elif i == 2:  # Last slide with loop end
+                shape = MagicMock()
+                shape.text_frame.text = "%endloop%"
+                shapes.append(shape)
+            else:  # Middle slide with content
+                shape = MagicMock()
+                shape.text_frame.text = "User: {{ user }}"
+                shapes.append(shape)
+
+            slide.shapes = shapes
+            # Add slide_layout attribute for duplicate_slide
+            slide.slide_layout = MagicMock()
+            slides_list.append(slide)
+
+        # Mock the slides collection with add_slide and __getitem__/__iter__
+        slides_mock = MagicMock()
+        slides_mock.__iter__.return_value = iter(slides_list)
+        slides_mock.__getitem__.side_effect = slides_list.__getitem__
+        slides_mock.__len__.return_value = len(slides_list)
+
+        def add_slide(layout):
+            # Return a new MagicMock slide with the given layout
+            new_slide = MagicMock()
+            new_slide.slide_layout = layout
+            # Mock shapes with _spTree attribute
+            shapes_mock = MagicMock()
+            shapes_mock._spTree = MagicMock()
+            new_slide.shapes = shapes_mock
+            return new_slide
+
+        slides_mock.add_slide.side_effect = add_slide
+        prs.slides = slides_mock
+
+        # Add a patch to detect loop directives during the test
+        with patch(
+            "template_reports.office_renderer.loops.is_loop_start"
+        ) as mock_is_start:
+            with patch(
+                "template_reports.office_renderer.loops.is_loop_end"
+            ) as mock_is_end:
+                # Configure mocks to return true only for specific slides
+                mock_is_start.side_effect = (
+                    lambda shape: shape.text_frame.text.startswith("%loop")
+                )
+                mock_is_end.side_effect = lambda shape: shape.text_frame.text.startswith(
+                    "%endloop"
+                )
+
+                # Process loops
+                result = process_loops(prs, context, None, errors)
+
+                # Check that we get 9 slides in the result (3 slides × 3 users)
+                self.assertEqual(len(result), 9)
+
+                # Check that there are no errors
+                self.assertEqual(len(errors), 0)
+
+    @patch("template_reports.office_renderer.pptx.Presentation")
+    def test_dot_notation_processing(self, mock_presentation):
+        """Test dot notation processing with minimal mocking."""
+        # Setup a simplified test focusing on dot notation
+        from template_reports.office_renderer.loops import process_loops, resolve_tag
+
+        # Prepare context with dot notation
+        context = {"program": {"members": ["Alice", "Bob"]}}
+        errors = []
+
+        # Create a minimalist presentation with 3 slides (start, content, end)
+        prs = MagicMock()
+        slides_list = []
+
+        # Create slides with appropriate shapes
+        for i in range(3):
+            slide = MagicMock()
+            shapes = []
+
+            if i == 0:  # First slide with loop start using dot notation
+                shape = MagicMock()
+                shape.text_frame.text = "%loop member in program.members%"
+                shapes.append(shape)
+            elif i == 2:  # Last slide with loop end
+                shape = MagicMock()
+                shape.text_frame.text = "%endloop%"
+                shapes.append(shape)
+            else:  # Middle slide with content
+                shape = MagicMock()
+                shape.text_frame.text = "Member: {{ member }}"
+                shapes.append(shape)
+
+            slide.shapes = shapes
+            # Add slide_layout attribute for duplicate_slide
+            slide.slide_layout = MagicMock()
+            slides_list.append(slide)
+
+        # Mock the slides collection with add_slide and __getitem__/__iter__
+        slides_mock = MagicMock()
+        slides_mock.__iter__.return_value = iter(slides_list)
+        slides_mock.__getitem__.side_effect = slides_list.__getitem__
+        slides_mock.__len__.return_value = len(slides_list)
+
+        def add_slide(layout):
+            # Return a new MagicMock slide with the given layout
+            new_slide = MagicMock()
+            new_slide.slide_layout = layout
+            # Mock shapes with _spTree attribute
+            shapes_mock = MagicMock()
+            shapes_mock._spTree = MagicMock()
+            new_slide.shapes = shapes_mock
+            return new_slide
+
+        slides_mock.add_slide.side_effect = add_slide
+        prs.slides = slides_mock
+
+        # Add a patch to detect loop directives during the test
+        with patch(
+            "template_reports.office_renderer.loops.is_loop_start"
+        ) as mock_is_start:
+            with patch(
+                "template_reports.office_renderer.loops.is_loop_end"
+            ) as mock_is_end:
+                # Configure mocks to return true only for specific slides
+                mock_is_start.side_effect = (
+                    lambda shape: shape.text_frame.text.startswith("%loop")
+                )
+                mock_is_end.side_effect = lambda shape: shape.text_frame.text.startswith(
+                    "%endloop"
+                )
+
+                # Test direct resolution of the dot notation path
+                members = resolve_tag("program.members", context, None)
+                self.assertEqual(members, ["Alice", "Bob"])
+
+                # Process loops
+                result = process_loops(prs, context, None, errors)
+
+                # Check that we get 6 slides in the result (3 slides × 2 members)
+                self.assertEqual(len(result), 6)
+
+                # Check that there are no errors
+                self.assertEqual(len(errors), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pptx_real_loops.py
+++ b/tests/test_pptx_real_loops.py
@@ -1,0 +1,121 @@
+import os
+import tempfile
+import unittest
+
+from pptx import Presentation
+from pptx.util import Inches
+
+from template_reports.office_renderer import render_pptx
+from template_reports.office_renderer.loops import is_loop_start, is_loop_end
+
+
+class TestRealPptxLoops(unittest.TestCase):
+    def setUp(self):
+        """Create a real PPTX file with loop directives for testing."""
+        # Create a temporary file for the PPTX
+        self.temp_pptx = tempfile.mktemp(suffix=".pptx")
+        self.output_pptx = tempfile.mktemp(suffix=".pptx")
+
+        # Create a presentation with loop directive
+        self.prs = Presentation()
+
+        # Create slides for the loop
+        self.slide1 = self.prs.slides.add_slide(self.prs.slide_layouts[5])
+        self.slide2 = self.prs.slides.add_slide(self.prs.slide_layouts[5])
+        self.slide3 = self.prs.slides.add_slide(self.prs.slide_layouts[5])
+
+        # Add loop start shape to slide 1
+        loop_start = self.slide1.shapes.add_textbox(
+            Inches(1), Inches(1), Inches(2), Inches(0.5)
+        )
+        loop_start.text_frame.text = "%loop user in users%"
+
+        # Add content shape to slide 2
+        user_info = self.slide2.shapes.add_textbox(
+            Inches(1), Inches(2), Inches(4), Inches(1)
+        )
+        user_info.text_frame.text = "Name: {{ user.name }}, Email: {{ user.email }}"
+
+        # Add loop end shape to slide 3
+        loop_end = self.slide3.shapes.add_textbox(
+            Inches(1), Inches(1), Inches(2), Inches(0.5)
+        )
+        loop_end.text_frame.text = "%endloop%"
+
+        # Save the presentation
+        self.prs.save(self.temp_pptx)
+
+        # Prepare the context
+        self.context = {
+            "users": [
+                {"name": "Alice", "email": "alice@example.com"},
+                {"name": "Bob", "email": "bob@example.com"},
+                {"name": "Charlie", "email": "charlie@example.com"},
+            ]
+        }
+
+    def tearDown(self):
+        # Clean up temporary files
+        for temp_file in [self.temp_pptx, self.output_pptx]:
+            if os.path.exists(temp_file):
+                os.remove(temp_file)
+
+    def test_real_pptx_loop_functionality(self):
+        """Test that loops work correctly in a real PPTX file."""
+        # Render the template with the context
+        output, errors = render_pptx(self.temp_pptx, self.context, self.output_pptx, None)
+
+        # Ensure no errors occurred
+        self.assertIsNone(errors, f"Errors occurred during rendering: {errors}")
+
+        # Load the output presentation to verify results
+        prs = Presentation(self.output_pptx)
+
+        # Print all text content for debugging
+        print("\nText content in all slides:")
+        for i, slide in enumerate(prs.slides):
+            print(f"Slide {i+1}:")
+            for j, shape in enumerate(slide.shapes):
+                if hasattr(shape, "text_frame") and hasattr(shape.text_frame, "text"):
+                    print(f"  Shape {j+1}: '{shape.text_frame.text}'")
+
+        # Verify loop directive shapes have been deleted
+        loop_directives_found = False
+        for i, slide in enumerate(prs.slides):
+            for shape in slide.shapes:
+                if hasattr(shape, "text_frame") and hasattr(shape.text_frame, "text"):
+                    text = shape.text_frame.text.strip()
+                    # Check if any text looks like a loop directive
+                    if (
+                        text.startswith("%loop")
+                        or text.startswith("% loop")
+                        or text == "%endloop%"
+                        or text == "% endloop %"
+                    ):
+                        loop_directives_found = True
+                        break
+            if loop_directives_found:
+                break
+
+        self.assertFalse(
+            loop_directives_found, "Loop directives found with text not cleared"
+        )
+
+        # Verify at least one user's content was correctly inserted
+        user_content_found = False
+        for user in self.context["users"]:
+            for slide in prs.slides:
+                for shape in slide.shapes:
+                    if hasattr(shape, "text_frame") and hasattr(shape.text_frame, "text"):
+                        if (
+                            user["name"] in shape.text_frame.text
+                            and user["email"] in shape.text_frame.text
+                        ):
+                            user_content_found = True
+                            print(f"Found user content: {shape.text_frame.text}")
+
+        self.assertTrue(user_content_found, "User content not found in any slide")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shape_removal.py
+++ b/tests/test_shape_removal.py
@@ -1,0 +1,56 @@
+"""
+Test the shape removal functionality.
+"""
+
+import os
+import tempfile
+import unittest
+
+from pptx import Presentation
+from pptx.util import Inches
+
+from template_reports.office_renderer.pptx_utils import remove_shape
+
+
+class TestShapeRemoval(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary file for the PPTX
+        self.temp_pptx = tempfile.mktemp(suffix=".pptx")
+
+        # Create a presentation with a textbox
+        self.prs = Presentation()
+        self.slide = self.prs.slides.add_slide(self.prs.slide_layouts[5])
+        self.textbox = self.slide.shapes.add_textbox(
+            Inches(1), Inches(1), Inches(2), Inches(0.5)
+        )
+        self.textbox.text_frame.text = "Test text"
+
+        # Save the presentation
+        self.prs.save(self.temp_pptx)
+
+    def tearDown(self):
+        # Clean up temporary files
+        if os.path.exists(self.temp_pptx):
+            os.remove(self.temp_pptx)
+
+    def test_remove_shape(self):
+        """Test that remove_shape correctly removes a shape from a slide."""
+        # Count initial shapes
+        shapes = [shape for shape in self.slide.shapes if not shape.is_placeholder]
+        initial_count = len(shapes)
+        self.assertEqual(initial_count, 1, "Should start with 1 shape")
+
+        # Remove the shape
+        remove_shape(self.textbox)
+
+        # Save and reload to ensure changes are applied
+        self.prs.save(self.temp_pptx)
+        prs = Presentation(self.temp_pptx)
+
+        # Count shapes after removal
+        shapes = [shape for shape in self.slide.shapes if not shape.is_placeholder]
+        self.assertEqual(len(shapes), 0, "Shape should be removed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduce loop directives to enable the repetition of slides for items in a collection within PowerPoint templates. Enhance documentation and tests to support this new feature, addressing feedback and fixing related issues. Ensure proper handling of shape removal and context extraction in the template processing.