### PR TITLE
Replace perm_user with check_permissions throughout the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Django Template Reports is a Django application that turns PowerPoint (PPTX) and
 * **Arithmetic operators** in expressions (``+``, ``-``, ``*``, ``/``).
 * **Dynamic table and worksheet expansion** when a placeholder resolves to a list.
 * **Chart support** where spreadsheet values inside charts contain placeholders.
-* **Permission enforcement** – data is filtered based on ``perm_user``.
+* **Permission enforcement** – data is filtered based on ``check_permissions`` function.
 * **Admin integration** with a flow to choose a template, configure context and generate ``ReportRun`` records.  Generated files can be downloaded individually or as a ZIP archive.
 * **Configurable filenames** using ``config.filename_template`` in ``ReportDefinition``.
 * **Global context** injection for values that should always be available.

--- a/template_reports/dummy_render.py
+++ b/template_reports/dummy_render.py
@@ -137,7 +137,7 @@ def main():
         input_file,
         context,
         output_file,
-        perm_user=None,
+        check_permissions=None,
     )
     if rendered:
         print("Rendered PPTX saved to:", rendered)

--- a/template_reports/models/base.py
+++ b/template_reports/models/base.py
@@ -25,7 +25,10 @@ class BaseReportDefinition(models.Model):
     name = models.CharField(max_length=255)
     description = models.TextField(blank=True)
 
-    file = models.FileField(upload_to="template_reports/templates/", storage=get_storage)
+    file = models.FileField(
+        upload_to="template_reports/templates/",
+        storage=get_storage,
+    )
 
     config = models.JSONField(
         default=dict, blank=True, help_text="Configuration JSON, including allowed models"

--- a/template_reports/office_renderer/charts.py
+++ b/template_reports/office_renderer/charts.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from pptx.chart.chart import Chart
 
 
-def process_chart(chart: Chart, context: dict, perm_user):
+def process_chart(chart: Chart, context: dict, check_permissions):
     """
     Read the current chart data, format text fields using the provided context,
     then update the chart with the new data.
@@ -23,18 +23,18 @@ def process_chart(chart: Chart, context: dict, perm_user):
     Parameters:
         chart: a pptx.chart.chart.Chart object.
         context: a dict used for formatting placeholders in text values.
-        perm_user: passed along for consistency (not used in this example).
+        check_permissions: function to check permissions for objects.
     """
 
     # Common kwargs
     process_kwargs = dict(
         context=context,
-        perm_user=perm_user,
+        check_permissions=check_permissions,
         fail_if_empty=True,
     )
 
     # (1) Process series DATA in the chart (excluding series names and categories).
-    all_processed_series_data = process_series_data(chart, context, perm_user)
+    all_processed_series_data = process_series_data(chart, context, check_permissions)
     # Transpose the data if the chart's axes are swapped.
     if chart_axes_are_swapped(chart):
         all_processed_series_data = list(zip(*all_processed_series_data))
@@ -104,7 +104,7 @@ def get_raw_chart_data(chart: Chart):
     return [[cell.value for cell in col] for col in worksheet.iter_cols()]
 
 
-def process_series_data(chart: Chart, context, perm_user):
+def process_series_data(chart: Chart, context, check_permissions):
     """
     Process the data in a chart, excluding the series names and categories.
 
@@ -128,7 +128,7 @@ def process_series_data(chart: Chart, context, perm_user):
             # Skip the first row, which is handled by the ChartData series/categories.
             col[1:],
             context,
-            perm_user,
+            check_permissions,
             as_float=True,
             fail_if_not_float=True,
             fail_if_empty=False,

--- a/template_reports/office_renderer/charts.py
+++ b/template_reports/office_renderer/charts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 from itertools import zip_longest
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Optional
 
 from pptx.chart.data import ChartData
 
@@ -15,7 +15,11 @@ if TYPE_CHECKING:
     from pptx.chart.chart import Chart
 
 
-def process_chart(chart: Chart, context: dict, check_permissions):
+def process_chart(
+    chart: Chart,
+    context: dict,
+    check_permissions: Optional[Callable[[object], bool]],
+):
     """
     Read the current chart data, format text fields using the provided context,
     then update the chart with the new data.
@@ -104,7 +108,11 @@ def get_raw_chart_data(chart: Chart):
     return [[cell.value for cell in col] for col in worksheet.iter_cols()]
 
 
-def process_series_data(chart: Chart, context, check_permissions):
+def process_series_data(
+    chart: Chart,
+    context: dict,
+    check_permissions: Optional[Callable[[object], bool]],
+):
     """
     Process the data in a chart, excluding the series names and categories.
 
@@ -127,8 +135,8 @@ def process_series_data(chart: Chart, context, check_permissions):
         process_text_list(
             # Skip the first row, which is handled by the ChartData series/categories.
             col[1:],
-            context,
-            check_permissions,
+            context=context,
+            check_permissions=check_permissions,
             as_float=True,
             fail_if_not_float=True,
             fail_if_empty=False,

--- a/template_reports/office_renderer/context_extractor.py
+++ b/template_reports/office_renderer/context_extractor.py
@@ -1,4 +1,5 @@
 import re
+from typing import IO
 from pptx import Presentation
 
 from .charts import get_raw_chart_data
@@ -44,7 +45,7 @@ def extract_top_level_context_keys_from_text(text: str) -> dict[str, list[str]]:
     }
 
 
-def extract_context_keys_from_xlsx(template) -> dict[str, list[str]]:
+def extract_context_keys_from_xlsx(template: str | IO[bytes]) -> dict[str, list[str]]:
     """
     Iterate through all worksheets and cells in the XLSX file (from a file path or file-like object),
     and return a dict with:
@@ -52,7 +53,7 @@ def extract_context_keys_from_xlsx(template) -> dict[str, list[str]]:
         - object_fields: sorted list of unique object keys
     """
     load_workbook = get_load_workbook()
-    
+
     # Load the workbook (support template as a file path or file-like object)
     if isinstance(template, str):
         workbook = load_workbook(template)
@@ -67,7 +68,7 @@ def extract_context_keys_from_xlsx(template) -> dict[str, list[str]]:
     texts = []
     for sheet_name in workbook.sheetnames:
         worksheet = workbook[sheet_name]
-        
+
         # Iterate through all cells that have values
         for row in worksheet.iter_rows():
             for cell in row:
@@ -86,7 +87,7 @@ def extract_context_keys_from_xlsx(template) -> dict[str, list[str]]:
     }
 
 
-def extract_context_keys_from_pptx(template) -> dict[str, list[str]]:
+def extract_context_keys_from_pptx(template: str | IO[bytes]) -> dict[str, list[str]]:
     """
     Iterate through all slides, shapes, paragraphs and table cells in the PPTX (from a file path or file-like object),
     merging split placeholders, and return a dict with:
@@ -149,18 +150,18 @@ def extract_context_keys_from_pptx(template) -> dict[str, list[str]]:
     }
 
 
-def extract_context_keys(template) -> dict[str, list[str]]:
+def extract_context_keys(template: str | IO[bytes]) -> dict[str, list[str]]:
     """
     Iterate through all slides/worksheets and their content in PPTX/XLSX files (from a file path or file-like object),
     and return a dict with:
         - simple_fields: sorted list of unique simple keys
         - object_fields: sorted list of unique object keys
-    
+
     This function automatically detects the file type and uses the appropriate extraction method.
     """
     # Identify the file type
     file_type = identify_file_type(template)
-    
+
     if file_type == "pptx":
         return extract_context_keys_from_pptx(template)
     elif file_type == "xlsx":

--- a/template_reports/office_renderer/images.py
+++ b/template_reports/office_renderer/images.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from io import BytesIO
+from typing import Callable, Optional
 from urllib.request import urlopen
 
 from openpyxl.drawing.image import Image as XLImage
@@ -11,7 +12,7 @@ from .constants import IMAGE_DIRECTIVES
 from .exceptions import ImageError
 
 
-def extract_image_directive(text: str | None) -> tuple[str | None, str | None]:
+def extract_image_directive(text: Optional[str]) -> tuple[Optional[str], Optional[str]]:
     """Return (url, mode) if *text* starts with an image directive."""
     if not text:
         return None, None
@@ -24,7 +25,7 @@ def extract_image_directive(text: str | None) -> tuple[str | None, str | None]:
     return None, None
 
 
-def extract_image_url(text: str | None) -> str | None:
+def extract_image_url(text: Optional[str]) -> Optional[str]:
     """Backward compatible helper returning only the URL."""
     url, _ = extract_image_directive(text)
     return url
@@ -50,9 +51,9 @@ def replace_shape_with_image(
     shape,
     slide,
     context: dict,
-    check_permissions=None,
-    url: str | None = None,
-    mode: str | None = None,
+    check_permissions: Optional[Callable[[object], bool]] = None,
+    url: Optional[str] = None,
+    mode: Optional[str] = None,
 ):
     """Replace *shape* with an image, keeping its position."""
 
@@ -63,12 +64,14 @@ def replace_shape_with_image(
     if not url:
         return
 
-    url = process_text(
+    result = process_text(
         url,
         context=context,
         check_permissions=check_permissions,
         mode="normal",
     )
+    assert isinstance(result, str), "Image URL must be a string"
+    url = result
 
     try:
         with urlopen(url) as resp:
@@ -111,9 +114,9 @@ def replace_cell_with_image(
     cell,
     worksheet,
     context: dict,
-    check_permissions=None,
-    url: str | None = None,
-    mode: str | None = None,
+    check_permissions: Optional[Callable[[object], bool]] = None,
+    url: Optional[str] = None,
+    mode: Optional[str] = None,
 ):
     """Replace the cell's value with an image anchored at the cell."""
 
@@ -124,12 +127,14 @@ def replace_cell_with_image(
     if not url:
         return
 
-    url = process_text(
+    result = process_text(
         url,
         context=context,
         check_permissions=check_permissions,
         mode="normal",
     )
+    assert isinstance(result, str), "Image URL must be a string"
+    url = result
 
     try:
         with urlopen(url) as resp:

--- a/template_reports/office_renderer/images.py
+++ b/template_reports/office_renderer/images.py
@@ -50,7 +50,7 @@ def replace_shape_with_image(
     shape,
     slide,
     context: dict,
-    perm_user=None,
+    check_permissions=None,
     url: str | None = None,
     mode: str | None = None,
 ):
@@ -66,7 +66,7 @@ def replace_shape_with_image(
     url = process_text(
         url,
         context=context,
-        perm_user=perm_user,
+        check_permissions=check_permissions,
         mode="normal",
     )
 
@@ -111,7 +111,7 @@ def replace_cell_with_image(
     cell,
     worksheet,
     context: dict,
-    perm_user=None,
+    check_permissions=None,
     url: str | None = None,
     mode: str | None = None,
 ):
@@ -127,7 +127,7 @@ def replace_cell_with_image(
     url = process_text(
         url,
         context=context,
-        perm_user=perm_user,
+        check_permissions=check_permissions,
         mode="normal",
     )
 

--- a/template_reports/office_renderer/paragraphs.py
+++ b/template_reports/office_renderer/paragraphs.py
@@ -1,3 +1,4 @@
+from typing import Callable, Optional
 from template_reports.templating import process_text
 from .exceptions import UnterminatedTagException
 
@@ -43,11 +44,12 @@ def merge_split_placeholders(paragraph):
     return paragraph
 
 
-def process_paragraph(paragraph, context, perm_user, mode="normal"):
+def process_paragraph(paragraph, context, check_permissions, mode="normal"):
     """
     Merge placeholders in a paragraph if a single placeholder ({{ ... }}) is split across multiple runs.
     Then process each run's text with process_text.
     """
+    
     # Use the helper to merge runs containing split placeholders.
     paragraph = merge_split_placeholders(paragraph)
 
@@ -56,7 +58,7 @@ def process_paragraph(paragraph, context, perm_user, mode="normal"):
         result = process_text(
             text=current_text,
             context=context,
-            perm_user=perm_user,
+            check_permissions=check_permissions,
             mode=mode,
             fail_if_empty=True,
         )

--- a/template_reports/office_renderer/paragraphs.py
+++ b/template_reports/office_renderer/paragraphs.py
@@ -44,12 +44,17 @@ def merge_split_placeholders(paragraph):
     return paragraph
 
 
-def process_paragraph(paragraph, context, check_permissions, mode="normal"):
+def process_paragraph(
+    paragraph,
+    context,
+    check_permissions: Optional[Callable[[object], bool]],
+    mode="normal",
+):
     """
     Merge placeholders in a paragraph if a single placeholder ({{ ... }}) is split across multiple runs.
     Then process each run's text with process_text.
     """
-    
+
     # Use the helper to merge runs containing split placeholders.
     paragraph = merge_split_placeholders(paragraph)
 

--- a/template_reports/office_renderer/pptx/compose.py
+++ b/template_reports/office_renderer/pptx/compose.py
@@ -12,7 +12,7 @@ def compose_pptx(
     slide_specs: list[dict],
     global_context: dict,
     output,
-    perm_user=None,
+    check_permissions=None,
     use_tagged_layouts=False,
     use_all_slides_as_layouts_by_title=False,
 ):
@@ -24,7 +24,7 @@ def compose_pptx(
         slide_specs: List of slide dictionaries, each containing 'layout' key and context data
         global_context: Global context dictionary
         output: Output file path or file-like object
-        perm_user: Permission user object
+        check_permissions: Permission checking function
         use_tagged_layouts: If True, include slides with % layout XXX % tags
         use_all_slides_as_layouts_by_title: If True, use all slides as layouts by title
 
@@ -105,7 +105,7 @@ def compose_pptx(
                 # Process the slide spec in case there are any template variables
                 for key, value in slide_spec.items():
                     slide_spec[key] = process_text_recursive(
-                        value, global_context, perm_user
+                        value, global_context, check_permissions
                     )
 
                 # Prepare slide context
@@ -129,7 +129,7 @@ def compose_pptx(
                     new_slide,
                     slide_context,
                     slide_number,
-                    perm_user,
+                    check_permissions,
                     errors,
                 )
 

--- a/template_reports/office_renderer/pptx/compose.py
+++ b/template_reports/office_renderer/pptx/compose.py
@@ -1,3 +1,5 @@
+from typing import Callable, Optional
+
 from pptx import Presentation
 
 from template_reports.templating.core import process_text_recursive
@@ -12,7 +14,7 @@ def compose_pptx(
     slide_specs: list[dict],
     global_context: dict,
     output,
-    check_permissions=None,
+    check_permissions: Optional[Callable[[object], bool]] = None,
     use_tagged_layouts=False,
     use_all_slides_as_layouts_by_title=False,
 ):
@@ -118,19 +120,19 @@ def compose_pptx(
                 # Handle placeholders first if provided
                 if placeholders:
                     process_placeholders(
-                        new_slide,
-                        placeholders,
-                        slide_number,
-                        errors,
+                        slide=new_slide,
+                        placeholders=placeholders,
+                        slide_number=slide_number,
+                        errors=errors,
                     )
 
                 # Process the slide
                 process_single_slide(
-                    new_slide,
-                    slide_context,
-                    slide_number,
-                    check_permissions,
-                    errors,
+                    slide=new_slide,
+                    context=slide_context,
+                    slide_number=slide_number,
+                    check_permissions=check_permissions,
+                    errors=errors,
                 )
 
             except Exception as e:

--- a/template_reports/office_renderer/pptx/loops.py
+++ b/template_reports/office_renderer/pptx/loops.py
@@ -61,15 +61,16 @@ def is_loop_end(shape) -> bool:
 def get_collection_from_collection_tag(
     collection_tag: str,
     context: dict,
-    perm_user,
+    check_permissions,
 ) -> tuple[Optional[Iterable[Any]], Optional[str]]:
     """
     Given a collection tag, resolve it to a collection in the context.
     This function is a placeholder and should be implemented based on your context resolution logic.
     """
+        
     # Get the collection from the context using resolve_tag
     try:
-        collection = resolve_tag(collection_tag, context, perm_user)
+        collection = resolve_tag(collection_tag, context, check_permissions=check_permissions)
     except Exception as e:
         return (
             None,
@@ -93,7 +94,7 @@ def get_collection_from_collection_tag(
     return collection, None
 
 
-def process_loops(prs: Presentation, context: dict, perm_user, errors: list[str]):
+def process_loops(prs: Presentation, context: dict, check_permissions, errors: list[str]):
     """
     Process loops in the presentation:
     - Identify loop sections (slides between %loop var in collection% and %endloop%)
@@ -136,7 +137,7 @@ def process_loops(prs: Presentation, context: dict, perm_user, errors: list[str]
                 if loop_variable_name and collection_tag:
                     has_loop_start = True
                     loop_collection, error = get_collection_from_collection_tag(
-                        collection_tag, context, perm_user
+                        collection_tag, context, check_permissions
                     )
                     if error:
                         errors.append(f"Error on slide {i + 1}: {error}")

--- a/template_reports/office_renderer/pptx/loops.py
+++ b/template_reports/office_renderer/pptx/loops.py
@@ -5,7 +5,7 @@ Functions to handle loop functionality in PPTX templates.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Iterable, Optional, Any
+from typing import TYPE_CHECKING, Callable, Iterable, Optional, Any
 
 from template_reports.templating import resolve_tag
 
@@ -61,16 +61,20 @@ def is_loop_end(shape) -> bool:
 def get_collection_from_collection_tag(
     collection_tag: str,
     context: dict,
-    check_permissions,
+    check_permissions: Optional[Callable[[object], bool]],
 ) -> tuple[Optional[Iterable[Any]], Optional[str]]:
     """
     Given a collection tag, resolve it to a collection in the context.
     This function is a placeholder and should be implemented based on your context resolution logic.
     """
-        
+
     # Get the collection from the context using resolve_tag
     try:
-        collection = resolve_tag(collection_tag, context, check_permissions=check_permissions)
+        collection = resolve_tag(
+            collection_tag,
+            context=context,
+            check_permissions=check_permissions,
+        )
     except Exception as e:
         return (
             None,
@@ -94,7 +98,12 @@ def get_collection_from_collection_tag(
     return collection, None
 
 
-def process_loops(prs: Presentation, context: dict, check_permissions, errors: list[str]):
+def process_loops(
+    prs: Presentation,
+    context: dict,
+    check_permissions: Optional[Callable[[object], bool]],
+    errors: list[str],
+):
     """
     Process loops in the presentation:
     - Identify loop sections (slides between %loop var in collection% and %endloop%)

--- a/template_reports/office_renderer/pptx/render.py
+++ b/template_reports/office_renderer/pptx/render.py
@@ -1,7 +1,5 @@
-from typing import Callable, Optional
+from typing import IO, Callable, Optional
 from pptx import Presentation
-
-from template_reports.templating.core import process_text
 
 from ..charts import process_chart
 from ..images import (
@@ -19,9 +17,9 @@ from .utils import remove_shape
 
 
 def render_pptx(
-    template,
+    template: str | IO[bytes],
     context: dict,
-    output,
+    output: str | IO[bytes],
     check_permissions: Optional[Callable[[object], bool]],
 ):
     """

--- a/template_reports/office_renderer/pptx/render.py
+++ b/template_reports/office_renderer/pptx/render.py
@@ -17,7 +17,7 @@ from .loops import (
 from .utils import remove_shape
 
 
-def render_pptx(template, context: dict, output, perm_user):
+def render_pptx(template, context: dict, output, check_permissions):
     """
     Render the PPTX template (a path string or a file-like object) using the provided context and save to output.
     'output' can be a path string or a file-like object. If it's a file-like object, it will be rewound after saving.
@@ -32,7 +32,7 @@ def render_pptx(template, context: dict, output, perm_user):
     errors: list[str] = []
 
     # Process loops first - identify loop sections and duplicate slides
-    slides_to_process = process_loops(prs, context, perm_user, errors)
+    slides_to_process = process_loops(prs, context, check_permissions, errors)
 
     # Process all slides including duplicated ones from loops
     for slide_info in slides_to_process:
@@ -52,7 +52,7 @@ def render_pptx(template, context: dict, output, perm_user):
             slide_context[slide_info["loop_var"]] = slide_info["loop_item"]
 
         # Process the slide
-        process_single_slide(slide, slide_context, slide_number, perm_user, errors)
+        process_single_slide(slide, slide_context, slide_number, check_permissions, errors)
 
     if errors:
         print("Rendering aborted due to the following errors:")
@@ -75,7 +75,7 @@ def process_single_slide(
     slide,
     context: dict,
     slide_number,
-    perm_user,
+    check_permissions,
     errors: list[str],
 ):
     """Process a single slide with the given context."""
@@ -86,7 +86,7 @@ def process_single_slide(
             continue
 
         # Process the shape content
-        process_shape_content(shape, slide, context, slide_number, perm_user, errors)
+        process_shape_content(shape, slide, context, slide_number, check_permissions, errors)
 
 
 def process_shape_content(
@@ -94,7 +94,7 @@ def process_shape_content(
     slide,
     context: dict,
     slide_number: int,
-    perm_user,
+    check_permissions,
     errors: list[str],
 ):
     """Process the content of a shape based on its type."""
@@ -105,7 +105,7 @@ def process_shape_content(
                 shape,
                 slide,
                 context=context,
-                perm_user=perm_user,
+                check_permissions=check_permissions,
             )
         except Exception as e:
             errors.append(f"Error processing image (slide {slide_number}): {e}")
@@ -125,7 +125,7 @@ def process_shape_content(
                 process_paragraph(
                     paragraph=paragraph,
                     context=context,
-                    perm_user=perm_user,
+                    check_permissions=check_permissions,
                     mode="normal",  # for text frames
                 )
             except Exception as e:
@@ -139,7 +139,7 @@ def process_shape_content(
                     process_table_cell(
                         cell=cell,
                         context=context,
-                        perm_user=perm_user,
+                        check_permissions=check_permissions,
                     )
                 except Exception as e:
                     errors.append(f"Error in table cell (slide {slide_number}): {e}")
@@ -150,7 +150,7 @@ def process_shape_content(
             process_chart(
                 chart=shape.chart,
                 context=context,
-                perm_user=perm_user,
+                check_permissions=check_permissions,
             )
         except Exception as e:
             errors.append(f"Error in chart (slide {slide_number}): {e}")

--- a/template_reports/office_renderer/pptx/render.py
+++ b/template_reports/office_renderer/pptx/render.py
@@ -1,3 +1,4 @@
+from typing import Callable, Optional
 from pptx import Presentation
 
 from template_reports.templating.core import process_text
@@ -17,7 +18,12 @@ from .loops import (
 from .utils import remove_shape
 
 
-def render_pptx(template, context: dict, output, check_permissions):
+def render_pptx(
+    template,
+    context: dict,
+    output,
+    check_permissions: Optional[Callable[[object], bool]],
+):
     """
     Render the PPTX template (a path string or a file-like object) using the provided context and save to output.
     'output' can be a path string or a file-like object. If it's a file-like object, it will be rewound after saving.
@@ -32,7 +38,12 @@ def render_pptx(template, context: dict, output, check_permissions):
     errors: list[str] = []
 
     # Process loops first - identify loop sections and duplicate slides
-    slides_to_process = process_loops(prs, context, check_permissions, errors)
+    slides_to_process = process_loops(
+        prs,
+        context=context,
+        check_permissions=check_permissions,
+        errors=errors,
+    )
 
     # Process all slides including duplicated ones from loops
     for slide_info in slides_to_process:
@@ -52,7 +63,13 @@ def render_pptx(template, context: dict, output, check_permissions):
             slide_context[slide_info["loop_var"]] = slide_info["loop_item"]
 
         # Process the slide
-        process_single_slide(slide, slide_context, slide_number, check_permissions, errors)
+        process_single_slide(
+            slide=slide,
+            context=slide_context,
+            slide_number=slide_number,
+            check_permissions=check_permissions,
+            errors=errors,
+        )
 
     if errors:
         print("Rendering aborted due to the following errors:")
@@ -74,8 +91,8 @@ def render_pptx(template, context: dict, output, check_permissions):
 def process_single_slide(
     slide,
     context: dict,
-    slide_number,
-    check_permissions,
+    slide_number: int,
+    check_permissions: Optional[Callable[[object], bool]],
     errors: list[str],
 ):
     """Process a single slide with the given context."""
@@ -86,7 +103,14 @@ def process_single_slide(
             continue
 
         # Process the shape content
-        process_shape_content(shape, slide, context, slide_number, check_permissions, errors)
+        process_shape_content(
+            shape,
+            slide=slide,
+            context=context,
+            slide_number=slide_number,
+            check_permissions=check_permissions,
+            errors=errors,
+        )
 
 
 def process_shape_content(
@@ -94,7 +118,7 @@ def process_shape_content(
     slide,
     context: dict,
     slide_number: int,
-    check_permissions,
+    check_permissions: Optional[Callable[[object], bool]],
     errors: list[str],
 ):
     """Process the content of a shape based on its type."""

--- a/template_reports/office_renderer/render.py
+++ b/template_reports/office_renderer/render.py
@@ -1,0 +1,57 @@
+from io import BytesIO
+from typing import IO, Callable, Optional
+
+from .pptx.render import render_pptx
+from .xlsx.render import render_xlsx
+from .utils import identify_file_type
+
+
+def render_from_file_stream(
+    template_file_stream: IO[bytes],
+    context: dict,
+    check_permissions: Optional[Callable[[object], bool]],
+):
+    """
+    Render the document template (a path string or a file-like object) using the provided context and save to output.
+    'output' can be a path string or a file-like object. If it's a file-like object, it will be rewound after saving.
+
+    We delegate
+
+    Parameters:
+        template: Path to the template document file or a file-like object
+        context: Dictionary with values to replace placeholders
+        output: Path or file-like object where to save the rendered result
+        check_permissions: Function to check permissions for objects
+
+    Returns:
+        Tuple (output, errors) where errors is None if successful or a list of errors
+    """
+
+    # Get the file type
+    file_type = identify_file_type(template_file_stream)
+
+    # Prepare an output stream to save to
+    output = BytesIO()
+
+    # Render if PPTX
+    if file_type == "pptx":
+        _, errors = render_pptx(
+            template=template_file_stream,
+            context=context,
+            output=output,
+            check_permissions=check_permissions,
+        )
+
+    # Render if XLSX
+    elif file_type == "xlsx":
+        _, errors = render_xlsx(
+            template=template_file_stream,
+            context=context,
+            output=output,
+            check_permissions=check_permissions,
+        )
+
+    else:
+        assert False, f"Unsupported file type: {file_type}"
+
+    return output, errors, file_type

--- a/template_reports/office_renderer/tables.py
+++ b/template_reports/office_renderer/tables.py
@@ -8,7 +8,7 @@ from .exceptions import CellOverwriteError, TableError
 from .paragraphs import process_paragraph
 
 
-def process_table_cell(cell, context: dict, perm_user=None):
+def process_table_cell(cell, context: dict, check_permissions=None):
     """
     Process the text in a table cell.
 
@@ -16,6 +16,7 @@ def process_table_cell(cell, context: dict, perm_user=None):
     If the result is a list, fill the column with the list items (and expand table if not enough room).
     Otherwise, process each paragraph in "normal" mode.
     """
+        
     cell_text = cell.text.strip()
 
     matches = get_matching_tags(cell_text)
@@ -25,7 +26,7 @@ def process_table_cell(cell, context: dict, perm_user=None):
         result = process_text(
             text=cell_text,
             context=context,
-            perm_user=perm_user,
+            check_permissions=check_permissions,
             mode="table",
             fail_if_empty=False,
         )
@@ -40,7 +41,7 @@ def process_table_cell(cell, context: dict, perm_user=None):
             process_paragraph(
                 paragraph=paragraph,
                 context=context,
-                perm_user=perm_user,
+                check_permissions=check_permissions,
                 mode="normal",
             )
 

--- a/template_reports/office_renderer/tables.py
+++ b/template_reports/office_renderer/tables.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Callable, Optional
 
 from pptx.table import _Cell
 
@@ -8,7 +9,11 @@ from .exceptions import CellOverwriteError, TableError
 from .paragraphs import process_paragraph
 
 
-def process_table_cell(cell, context: dict, check_permissions=None):
+def process_table_cell(
+    cell,
+    context: dict,
+    check_permissions: Optional[Callable[[object], bool]] = None,
+):
     """
     Process the text in a table cell.
 
@@ -16,7 +21,7 @@ def process_table_cell(cell, context: dict, check_permissions=None):
     If the result is a list, fill the column with the list items (and expand table if not enough room).
     Otherwise, process each paragraph in "normal" mode.
     """
-        
+
     cell_text = cell.text.strip()
 
     matches = get_matching_tags(cell_text)

--- a/template_reports/office_renderer/utils.py
+++ b/template_reports/office_renderer/utils.py
@@ -5,6 +5,7 @@ This module provides helper functions for working with Microsoft Office document
 including file type detection and workbook loading utilities.
 """
 
+from typing import IO
 import zipfile
 
 from .exceptions import UnsupportedFileType
@@ -33,7 +34,7 @@ def get_load_workbook():
     return load_workbook
 
 
-def identify_file_type(file_input):
+def identify_file_type(file_input: str | IO[bytes]):
     """
     Identifies the type of Office file by examining its internal structure.
 

--- a/template_reports/office_renderer/xlsx/render.py
+++ b/template_reports/office_renderer/xlsx/render.py
@@ -2,7 +2,7 @@ from ..utils import get_load_workbook
 from .worksheets import process_worksheet
 
 
-def render_xlsx(template, context, output, perm_user):
+def render_xlsx(template, context, output, check_permissions):
     """
     Render the XLSX template (a path string or a file-like object) using the provided context and save to output.
     'output' can be a path string or a file-like object. If it's a file-like object, it will be rewound after saving.
@@ -11,7 +11,7 @@ def render_xlsx(template, context, output, perm_user):
         template: Path to the template XLSX file or a file-like object
         context: Dictionary with values to replace placeholders
         output: Path or file-like object where to save the rendered result
-        perm_user: User object for permission checks when processing placeholders
+        check_permissions: Function to check permissions for objects
 
     Returns:
         Tuple (output, errors) where errors is None if successful or a list of errors
@@ -42,7 +42,7 @@ def render_xlsx(template, context, output, perm_user):
             process_worksheet(
                 worksheet=worksheet,
                 context=sheet_context,
-                perm_user=perm_user,
+                check_permissions=check_permissions,
             )
 
         except Exception as e:

--- a/template_reports/office_renderer/xlsx/render.py
+++ b/template_reports/office_renderer/xlsx/render.py
@@ -1,12 +1,13 @@
-from typing import Callable, Optional
+from typing import IO, Callable, Optional
+
 from ..utils import get_load_workbook
 from .worksheets import process_worksheet
 
 
 def render_xlsx(
-    template,
+    template: str | IO[bytes],
     context: dict,
-    output,
+    output: str | IO[bytes],
     check_permissions: Optional[Callable[[object], bool]],
 ):
     """

--- a/template_reports/office_renderer/xlsx/render.py
+++ b/template_reports/office_renderer/xlsx/render.py
@@ -1,8 +1,14 @@
+from typing import Callable, Optional
 from ..utils import get_load_workbook
 from .worksheets import process_worksheet
 
 
-def render_xlsx(template, context, output, check_permissions):
+def render_xlsx(
+    template,
+    context: dict,
+    output,
+    check_permissions: Optional[Callable[[object], bool]],
+):
     """
     Render the XLSX template (a path string or a file-like object) using the provided context and save to output.
     'output' can be a path string or a file-like object. If it's a file-like object, it will be rewound after saving.

--- a/template_reports/office_renderer/xlsx/worksheets.py
+++ b/template_reports/office_renderer/xlsx/worksheets.py
@@ -4,14 +4,15 @@ from ..exceptions import CellOverwriteError
 from ..images import should_replace_cell_with_image, replace_cell_with_image
 
 
-def process_worksheet(worksheet, context: dict, perm_user=None):
+def process_worksheet(worksheet, context: dict, check_permissions=None):
     """
     Process a worksheet, replacing placeholders with values from the context.
     When a placeholder resolves to a list, it expands into multiple rows in the column.
     """
+
     process_kwargs = {
         "context": context,
-        "perm_user": perm_user,
+        "check_permissions": check_permissions,
         "as_float": True,
         "fail_if_not_float": False,
         "fail_if_empty": False,
@@ -26,7 +27,7 @@ def process_worksheet(worksheet, context: dict, perm_user=None):
                     cell,
                     worksheet,
                     context=context,
-                    perm_user=perm_user,
+                    check_permissions=check_permissions,
                 )
                 continue
 

--- a/template_reports/office_renderer/xlsx/worksheets.py
+++ b/template_reports/office_renderer/xlsx/worksheets.py
@@ -1,10 +1,15 @@
+from typing import Callable, Optional
 from template_reports.templating.list import process_text_list
 
 from ..exceptions import CellOverwriteError
 from ..images import should_replace_cell_with_image, replace_cell_with_image
 
 
-def process_worksheet(worksheet, context: dict, check_permissions=None):
+def process_worksheet(
+    worksheet,
+    context: dict,
+    check_permissions: Optional[Callable[[object], bool]] = None,
+):
     """
     Process a worksheet, replacing placeholders with values from the context.
     When a placeholder resolves to a list, it expands into multiple rows in the column.

--- a/template_reports/templating/core.py
+++ b/template_reports/templating/core.py
@@ -10,6 +10,7 @@ Permission checking is enforced during parsing.
 """
 
 import re
+from typing import Callable, Optional
 
 from .exceptions import BadTemplateModeError, EmptyDataException
 from .resolve import resolve_formatted_tag
@@ -23,7 +24,7 @@ def get_matching_tags(text: str):
 def process_text(
     text: str,
     context: dict,
-    perm_user=None,
+    check_permissions: Optional[Callable[[object], bool]] = None,
     mode: str = "normal",
     delimiter: str = ", ",
     fail_if_empty: bool = False,
@@ -68,7 +69,7 @@ def process_text(
         value = resolve_formatted_tag(
             expr=raw_expr,
             context=context,
-            perm_user=perm_user,
+            check_permissions=check_permissions,
         )
 
         # If the value is empty and fail_if_empty is set, raise an error.
@@ -108,19 +109,19 @@ def process_text(
 def process_text_recursive(
     obj,
     context: dict,
-    perm_user=None,
+    check_permissions: Optional[Callable[[object], bool]] = None,
     mode: str = "normal",
     delimiter: str = ", ",
     fail_if_empty: bool = False,
 ):
 
     if isinstance(obj, str):
-        return process_text(obj, context, perm_user, mode, delimiter, fail_if_empty)
+        return process_text(obj, context, check_permissions, mode, delimiter, fail_if_empty)
 
     elif isinstance(obj, list):
         return [
             process_text_recursive(
-                item, context, perm_user, mode, delimiter, fail_if_empty
+                item, context, check_permissions, mode, delimiter, fail_if_empty
             )
             for item in obj
         ]
@@ -128,7 +129,7 @@ def process_text_recursive(
     elif isinstance(obj, dict):
         return {
             key: process_text_recursive(
-                value, context, perm_user, mode, delimiter, fail_if_empty
+                value, context, check_permissions, mode, delimiter, fail_if_empty
             )
             for key, value in obj.items()
         }

--- a/template_reports/templating/core.py
+++ b/template_reports/templating/core.py
@@ -116,7 +116,9 @@ def process_text_recursive(
 ):
 
     if isinstance(obj, str):
-        return process_text(obj, context, check_permissions, mode, delimiter, fail_if_empty)
+        return process_text(
+            obj, context, check_permissions, mode, delimiter, fail_if_empty
+        )
 
     elif isinstance(obj, list):
         return [

--- a/template_reports/templating/formatting.py
+++ b/template_reports/templating/formatting.py
@@ -98,10 +98,4 @@ def format_value(value: list | str, format_expr: str):
             f"Error formatting value '{value}' with format '{format_expr}': {str(e)}"
         )
 
-    # If the format string contains a comma, split it to retrieve multiple attributes.
-    # elif "," in format_expr:
-    #     attrs = [a.strip() for a in format_expr.split(",")]
-    #     return tuple(
-    #         resolve_tag(f"{value_expr}.{attr}", context, perm_user=perm_user)
-    #         for attr in attrs
-    #     )
+

--- a/template_reports/templating/list.py
+++ b/template_reports/templating/list.py
@@ -1,3 +1,4 @@
+from typing import Callable, Optional
 from .core import get_matching_tags, process_text
 from .exceptions import BadFloatDataResultError
 
@@ -5,7 +6,7 @@ from .exceptions import BadFloatDataResultError
 def process_text_list(
     items: list,
     context: dict,
-    perm_user,
+    check_permissions: Optional[Callable[[object], bool]],
     as_float: bool,
     fail_if_not_float: bool = False,
     fail_if_empty: bool = False,
@@ -20,7 +21,7 @@ def process_text_list(
             text=str(t),
             mode=m,
             context=context,
-            perm_user=perm_user,
+            check_permissions=check_permissions,
             fail_if_empty=fail_if_empty,
         )
 

--- a/template_reports/templating/permissions.py
+++ b/template_reports/templating/permissions.py
@@ -2,68 +2,38 @@
 Permissions utility module for the templating system.
 """
 
+from typing import Callable
+
 from .exceptions import PermissionDeniedException
-
-
-def is_django_object(obj):
-    return hasattr(obj, "_meta")
-
-
-def has_view_permission(obj, perm_user):
-    """
-    If perm_user is None, returns False.
-    For Django-like objects (with _meta), returns perm_user.has_perm("view", obj).
-    For all other objects, returns True.
-    """
-    if perm_user is None:
-        return False
-    if is_django_object(obj):
-        return perm_user.has_perm("view", obj)
-    return True
-
-
-def _check_permissions(item, perm_user):
-    """
-    Check permission for a single item.
-    Returns a tuple (item, True) if the item passes the permission check.
-    Otherwise, returns (None, False). If raise_exception is True, raises PermissionDeniedException immediately.
-    """
-    if is_django_object(item) and not has_view_permission(item, perm_user):
-        msg = f"Permission denied on: {item}"
-        raise PermissionDeniedException(msg)
-    return (item, True)
 
 
 def enforce_permissions(
     value,
-    perm_user,
+    check_permissions: Callable[[object], bool],
     raise_exception=True,
 ):
     """
-    Enforce permission checks on the resolved value by delegating per-item permission logic to _check_permissions.
+    Enforce permission checks on the resolved value.
 
-    - If check_permissions is False or no perm_user is provided, returns the value unmodified.
-    - For list values: iterates once, replaces any item failing _check_permissions (i.e. gets None) by filtering it out.
-      If any item fails, the first error message is already appended (via _check_permissions).
-    - For a single value: returns "" if _check_permissions returns None.
+    - If check_permissions is None, returns the value unmodified.
+    - For list values: iterates once, filters out any item failing permission check.
+      If any item fails, raises PermissionDeniedException.
+    - For a single value: returns "" if permission check fails, raises PermissionDeniedException otherwise.
     """
-    if perm_user is None:
+    if check_permissions is None:
         return value
 
     # If value is a list, check each item.
     if isinstance(value, list):
         permitted = []
         for item in value:
-            res, success = _check_permissions(
-                item,
-                perm_user,
-            )
-            if success:
-                permitted.append(res)
+            if not check_permissions(item):
+                msg = f"Permission denied on: {item}"
+                raise PermissionDeniedException(msg)
+            permitted.append(item)
         return permitted
     else:
-        res, success = _check_permissions(
-            value,
-            perm_user,
-        )
-        return res if success else ""
+        if not check_permissions(value):
+            msg = f"Permission denied on: {value}"
+            raise PermissionDeniedException(msg)
+        return value

--- a/template_reports/templating/permissions.py
+++ b/template_reports/templating/permissions.py
@@ -2,14 +2,14 @@
 Permissions utility module for the templating system.
 """
 
-from typing import Callable
+from typing import Callable, Optional
 
 from .exceptions import PermissionDeniedException
 
 
 def enforce_permissions(
     value,
-    check_permissions: Callable[[object], bool],
+    check_permissions: Optional[Callable[[object], bool]],
     raise_exception=True,
 ):
     """

--- a/template_reports/templating/resolve.py
+++ b/template_reports/templating/resolve.py
@@ -131,7 +131,7 @@ def resolve_formatted_tag(
             break
 
     # Resolve the tag expression (without the formatting part).
-    value = resolve_tag(value_expr, context, check_permissions=check_permissions)
+    value = resolve_tag(value_expr, context=context, check_permissions=check_permissions)
 
     # Perform mathematical operations if applicable.
     if math_operator and math_operand is not None:
@@ -169,7 +169,9 @@ def apply_math_operator(value, math_operator, operand):
 
 
 def substitute_inner_tags(
-    expr: str, context, check_permissions: Optional[Callable[[object], bool]] = None
+    expr: str,
+    context,
+    check_permissions: Optional[Callable[[object], bool]] = None,
 ) -> str:
     """
     Replace any sub-tags embedded within a tag expression. A sub-tag is any substring
@@ -202,7 +204,9 @@ def substitute_inner_tags(
 
 
 def resolve_tag(
-    expr, context, check_permissions: Optional[Callable[[object], bool]] = None
+    expr: str,
+    context: dict,
+    check_permissions: Optional[Callable[[object], bool]] = None,
 ):
     """
     Resolve a dotted tag expression using the provided context. The expression can consist
@@ -249,7 +253,7 @@ def resolve_tag(
     return current
 
 
-def split_expression(expr):
+def split_expression(expr: str):
     """
     Split a dotted expression into its individual segments.
 
@@ -267,7 +271,9 @@ def split_expression(expr):
 
 
 def resolve_segment(
-    current, segment, check_permissions: Optional[Callable[[object], bool]] = None
+    current,
+    segment,
+    check_permissions: Optional[Callable[[object], bool]] = None,
 ):
     """
     Resolve a single segment of a dotted tag expression.

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -88,7 +88,7 @@ class TestProcessChart(unittest.TestCase):
         ):
 
             # Call process_chart
-            process_chart(dummy_chart, context, perm_user=None)
+            process_chart(dummy_chart, context, None)
 
         # Verify that load_workbook was called with the BytesIO instance
         mock_openpyxl.load_workbook.assert_called_once_with(mock_bytesio)
@@ -147,7 +147,7 @@ class TestProcessChartFull(unittest.TestCase):
                 series.__class__.name = property(lambda self: "Series {{ test }}")
 
         # Now process the chart
-        process_chart(chart, context, perm_user=None)
+        process_chart(chart, context, None)
 
         # Now check that the chart's data was updated:
         # Retrieve the categories from the first plot.
@@ -205,7 +205,7 @@ class TestProcessChartFull(unittest.TestCase):
         }
 
         # Process the chart. This should update its data by expanding the list placeholders.
-        process_chart(chart, context, perm_user=None)
+        process_chart(chart, context, None)
 
         # Verify that categories were replaced by the list of user names.
         new_categories = [str(cat) for cat in chart.plots[0].categories]
@@ -236,7 +236,7 @@ class TestProcessChartFull(unittest.TestCase):
             "none_value": None,
         }
         with self.assertRaises(EmptyDataException):
-            process_chart(chart, context, perm_user=None)
+            process_chart(chart, context, None)
 
     def test_chart_with_empty_placeholder_value(self):
         """Test that a chart placeholder resolving to an empty value results in None or '' in the chart data (should fail currently)."""
@@ -259,7 +259,7 @@ class TestProcessChartFull(unittest.TestCase):
             "none_value": None,
             "empty_value": "",
         }
-        process_chart(chart, context, perm_user=None)
+        process_chart(chart, context, None)
         # Check series values
         values_1 = list(chart.series[0].values)
         self.assertEqual(values_1[0], 0.0)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -42,7 +42,7 @@ class TestProcessTextList(unittest.TestCase):
         """Test processing a list of simple text items."""
         items = ["Hello, {{ user.name }}", "Email: {{ user.email }}"]
         result = process_text_list(
-            items=items, context=self.context, perm_user=None, as_float=False
+            items=items, context=self.context, check_permissions=None, as_float=False
         )
         self.assertEqual(result, ["Hello, Alice", "Email: alice@example.com"])
 
@@ -50,7 +50,7 @@ class TestProcessTextList(unittest.TestCase):
         """Test table mode expansion for a single item with a list-resolving placeholder."""
         items = ["User: {{ users.name }}"]
         result = process_text_list(
-            items=items, context=self.context, perm_user=None, as_float=False
+            items=items, context=self.context, check_permissions=None, as_float=False
         )
         self.assertEqual(result, ["User: Bob", "User: Carol"])
 
@@ -58,7 +58,7 @@ class TestProcessTextList(unittest.TestCase):
         """Test that items are converted to float when as_float is True."""
         items = ["{{ numbers.0 }}", "{{ numbers.1 }}", "{{ numbers.2 }}"]
         result = process_text_list(
-            items=items, context=self.context, perm_user=None, as_float=True
+            items=items, context=self.context, check_permissions=None, as_float=True
         )
         self.assertEqual(result, [1.0, 2.0, 3.0])
 
@@ -68,7 +68,7 @@ class TestProcessTextList(unittest.TestCase):
         result = process_text_list(
             items=items,
             context=self.context,
-            perm_user=None,
+            check_permissions=None,
             as_float=True,
             fail_if_not_float=False,
         )
@@ -81,7 +81,7 @@ class TestProcessTextList(unittest.TestCase):
             process_text_list(
                 items=items,
                 context=self.context,
-                perm_user=None,
+                check_permissions=None,
                 as_float=True,
                 fail_if_not_float=True,
             )
@@ -93,7 +93,7 @@ class TestProcessTextList(unittest.TestCase):
         result = process_text_list(
             items=items,
             context=self.context,
-            perm_user=None,
+            check_permissions=None,
             as_float=True,
             fail_if_not_float=False,
         )
@@ -101,7 +101,7 @@ class TestProcessTextList(unittest.TestCase):
         result = process_text_list(
             items=items,
             context=self.context,
-            perm_user=None,
+            check_permissions=None,
             as_float=True,
             fail_if_not_float=True,
         )
@@ -114,7 +114,7 @@ class TestProcessTextList(unittest.TestCase):
         result = process_text_list(
             items=items,
             context=self.context,
-            perm_user=None,
+            check_permissions=None,
             as_float=True,
             fail_if_not_float=False,
         )
@@ -122,7 +122,7 @@ class TestProcessTextList(unittest.TestCase):
         result = process_text_list(
             items=items,
             context=self.context,
-            perm_user=None,
+            check_permissions=None,
             as_float=True,
             fail_if_not_float=True,
         )

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,10 +1,10 @@
 import unittest
 from template_reports.templating.permissions import (
-    is_django_object,
-    has_view_permission,
     enforce_permissions,
 )
 from template_reports.templating.exceptions import PermissionDeniedException
+
+from tests.utils import has_view_permission, is_django_object
 
 
 # Dummy request user for permission testing.
@@ -43,52 +43,64 @@ class TestPermissions(unittest.TestCase):
         # Deny any object whose name contains "deny".
         self.request_user = DummyRequestUser(deny_pattern="deny")
 
-    def test_is_django_object(self):
-        self.assertFalse(is_django_object(self.non_django))
-        self.assertTrue(is_django_object(self.django_allowed))
+    # def test_is_django_object(self):
+    #     self.assertFalse(is_django_object(self.non_django))
+    #     self.assertTrue(is_django_object(self.django_allowed))
 
-    def test_has_view_permission(self):
-        # Non-Django objects always return True.
-        self.assertTrue(has_view_permission(self.non_django, self.request_user))
-        # Allowed Django-like object.
-        self.assertTrue(has_view_permission(self.django_allowed, self.request_user))
-        # Denied Django-like object.
-        self.assertFalse(has_view_permission(self.django_denied, self.request_user))
-        # With no request_user, should return False on Django objects.
-        self.assertFalse(has_view_permission(self.django_allowed, None))
+    # def test_has_view_permission(self):
+    #     # Non-Django objects always return True.
+    #     self.assertTrue(has_view_permission(self.non_django, self.request_user))
+    #     # Allowed Django-like object.
+    #     self.assertTrue(has_view_permission(self.django_allowed, self.request_user))
+    #     # Denied Django-like object.
+    #     self.assertFalse(has_view_permission(self.django_denied, self.request_user))
+    #     # With no request_user, should return False on Django objects.
+    #     self.assertFalse(has_view_permission(self.django_allowed, None))
 
     def test_enforce_permissions_single_value(self):
+        # Create check_permissions lambda
+        check_permissions = lambda o: has_view_permission(o, self.request_user)
+
         # For a non-Django object, value is returned unchanged.
         val = "test value"
-        res = enforce_permissions(val, self.request_user, True)
+        res = enforce_permissions(val, check_permissions, True)
         self.assertEqual(res, val)
 
         # For allowed Django-like object.
-        res_allowed = enforce_permissions(self.django_allowed, self.request_user, True)
+        res_allowed = enforce_permissions(self.django_allowed, check_permissions, True)
         self.assertEqual(res_allowed, self.django_allowed)
 
         # For denied Django-like object, expect an exception instead of empty string.
         with self.assertRaises(PermissionDeniedException):
-            enforce_permissions(self.django_denied, self.request_user, True)
+            enforce_permissions(self.django_denied, check_permissions, True)
 
     def test_enforce_permissions_list(self):
+        # Create check_permissions lambda
+        check_permissions = lambda o: has_view_permission(o, self.request_user)
+
         # Test on a list containing an allowed object and a denied object.
         values = [self.django_allowed, self.django_denied, self.non_django]
         with self.assertRaises(PermissionDeniedException):
-            enforce_permissions(values, self.request_user, True)
+            enforce_permissions(values, check_permissions, True)
 
     def test_enforce_permissions_single_value_exception(self):
+        # Create check_permissions lambda
+        check_permissions = lambda o: has_view_permission(o, self.request_user)
+
         # When permission is denied and raise_exception is True.
         with self.assertRaises(PermissionDeniedException):
             enforce_permissions(
                 self.django_denied,
-                self.request_user,
+                check_permissions,
             )
 
     def test_enforce_permissions_list_exception(self):
+        # Create check_permissions lambda
+        check_permissions = lambda o: has_view_permission(o, self.request_user)
+
         values = [self.django_allowed, self.django_denied, self.non_django]
         with self.assertRaises(PermissionDeniedException):
-            enforce_permissions(values, self.request_user)
+            enforce_permissions(values, check_permissions)
 
 
 if __name__ == "__main__":

--- a/tests/test_pptx_integration.py
+++ b/tests/test_pptx_integration.py
@@ -97,7 +97,7 @@ class TestRendererIntegration(unittest.TestCase):
             self.temp_input,
             self.context,
             self.temp_output,
-            perm_user=None,
+            None,
         )
         self.assertIsNone(errors)
 
@@ -152,7 +152,7 @@ class TestRendererIntegration(unittest.TestCase):
         }
         context = {"user": program["users"][0], "program": program}
         # Render
-        rendered, errors = render_pptx(temp_input, context, temp_output, perm_user=None)
+        rendered, errors = render_pptx(temp_input, context, temp_output, None)
         self.assertIsNone(errors)
         prs_out = Presentation(rendered)
         table_shape_out = None
@@ -199,7 +199,7 @@ class TestRendererIntegration(unittest.TestCase):
         # Add dummy callable to context
         self.context["dummy"] = DummyCallable()
         rendered, errors = render_pptx(
-            self.temp_input, self.context, self.temp_output, perm_user=None
+            self.temp_input, self.context, self.temp_output, None
         )
         self.assertIsNone(errors)
         prs_out = Presentation(rendered)
@@ -226,7 +226,7 @@ class TestRendererIntegration(unittest.TestCase):
         self.prs.save(self.temp_input)
 
         rendered, errors = render_pptx(
-            self.temp_input, self.context, self.temp_output, perm_user=None
+            self.temp_input, self.context, self.temp_output, None
         )
         self.assertIsNone(errors)
 
@@ -254,7 +254,7 @@ class TestRendererIntegration(unittest.TestCase):
         self.prs.save(self.temp_input)
 
         rendered, errors = render_pptx(
-            self.temp_input, self.context, self.temp_output, perm_user=None
+            self.temp_input, self.context, self.temp_output, None
         )
         self.assertIsNone(errors)
 

--- a/tests/test_pptx_unit.py
+++ b/tests/test_pptx_unit.py
@@ -7,6 +7,8 @@ from pptx.util import Inches
 
 from template_reports.office_renderer import render_pptx
 
+from tests.utils import has_view_permission
+
 
 # Dummy objects for testing renderer behavior.
 class DummyUser:
@@ -67,7 +69,7 @@ class TestRendererUnit(unittest.TestCase):
             self.temp_input,
             self.context,
             self.temp_output,
-            perm_user=None,
+            None,
         )
         # Load output and check text from slide[0], shape[0].
         prs_out = Presentation(rendered)
@@ -86,7 +88,7 @@ class TestRendererUnit(unittest.TestCase):
             self.temp_input,
             self.context,
             self.temp_output,
-            perm_user=None,
+            None,
         )
         prs_out = Presentation(rendered)
         shape = prs_out.slides[0].shapes[self.shape_index]
@@ -98,11 +100,12 @@ class TestRendererUnit(unittest.TestCase):
         # Retrieve entire user (Django-like object), forcing permission denial:
         self.textframe.paragraphs[0].text = "{{ user }}"
         self.prs.save(self.temp_input)
+        check_permissions = lambda obj: has_view_permission(obj, self.request_user)
         _, errors = render_pptx(
             self.temp_input,
             self.context,
             self.temp_output,
-            perm_user=self.request_user,
+            check_permissions,
         )
         self.assertTrue(len(errors) == 1)
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -7,12 +7,12 @@ from template_reports.templating.resolve import (
     split_expression,
     resolve_segment,
 )
-from template_reports.templating.parse import get_nested_attr
 from template_reports.templating.exceptions import (
     BadTagException,
     MissingDataException,
-    TagCallableException,
-)  # Added import
+)
+
+from tests.utils import has_view_permission
 
 
 # Dummy class for testing nested attribute and filtering.
@@ -153,7 +153,11 @@ class TestParser(unittest.TestCase):
         req_user = RequestUser()
 
         expr = "container.users[is_active=True, name=Allow]"
-        resolved = resolve_formatted_tag(expr, context, perm_user=req_user)
+        # Create check_permissions lambda
+        check_permissions = lambda obj: has_view_permission(obj, req_user)
+        resolved = resolve_formatted_tag(
+            expr, context, check_permissions=check_permissions
+        )
         self.assertEqual(resolved, [users[0]])
 
     def test_empty_expression(self):

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -246,7 +246,7 @@ class TestTables(unittest.TestCase):
         orig = tables.process_paragraph
         try:
 
-            def dummy_pp(paragraph, context, perm_user, mode):
+            def dummy_pp(paragraph, context, check_permissions, mode):
                 paragraph.clear()
                 paragraph.add_run().text = "Repl"
 

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -10,6 +10,8 @@ from template_reports.templating.exceptions import (
 )
 from template_reports.templating.core import process_text
 
+from tests.utils import has_view_permission
+
 
 # ----- Dummy Classes for Testing -----
 
@@ -87,7 +89,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         expected = self.now.strftime("%B %d, %Y")
@@ -102,7 +104,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         expected = ", ".join(u.email for u in self.program["users"])
@@ -116,7 +118,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         expected = self.context["meeting_time"].strftime("%B %d, %Y")
@@ -129,7 +131,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
             result2 = process_text(
                 tpl2,
                 self.context,
-                perm_user=None,
+                check_permissions=None,
                 mode="normal",
             )
         expected2 = self.now.strftime("%B %d, %Y")
@@ -141,7 +143,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         # Expected: "The program is: Test Program. Users: alice-three@example.com, bob@example.com, deny@example.com are active."
@@ -156,7 +158,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         # Expected: "All emails: alice-three@example.com, bob@example.com, deny@example.com are active."
@@ -171,7 +173,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         expected = f"All emails: {', '.join(u.email for u in self.program['users'])}. User is: {self.user1.name}."
@@ -182,10 +184,11 @@ class TestTemplatingNormalMode(unittest.TestCase):
         tpl = "{{ program.users.email }}"
         # Now, with permission checking enabled, self.user3 ("DenyUser") should be filtered out.
         with self.assertRaises(PermissionDeniedException):
+            check_permissions = lambda obj: has_view_permission(obj, self.request_user)
             process_text(
                 tpl,
                 self.context,
-                perm_user=self.request_user,
+                check_permissions=check_permissions,
                 mode="normal",
             )
 
@@ -194,7 +197,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "Empty tag: .")
@@ -205,7 +208,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
             process_text(
                 tpl,
                 self.context,
-                perm_user=None,
+                check_permissions=None,
                 mode="normal",
             )
 
@@ -217,7 +220,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "Display: ALICE")
@@ -227,7 +230,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         # The filtered list will join a single email into a string.
@@ -242,10 +245,11 @@ class TestTemplatingNormalMode(unittest.TestCase):
         denier = DenyAllUser()
         tpl = "{{ program.users.email }}"
         with self.assertRaises(PermissionDeniedException):
+            check_permissions = lambda obj: has_view_permission(obj, denier)
             process_text(
                 tpl,
                 self.context,
-                perm_user=denier,
+                check_permissions=check_permissions,
                 mode="normal",
             )
 
@@ -255,7 +259,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="table",
         )
         self.assertEqual(result, "100")
@@ -266,7 +270,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="table",
         )
         self.assertEqual(result, ["100"])
@@ -277,7 +281,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(
@@ -289,7 +293,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, tpl)
@@ -301,7 +305,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         expected_date = self.now.strftime("%B %d, %Y")
@@ -314,7 +318,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "The count is 42")
@@ -325,7 +329,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "Price: 19.95")
@@ -336,7 +340,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "14.0")
@@ -347,7 +351,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "6.0")
@@ -358,7 +362,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "3.14")
@@ -369,7 +373,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "8.15")
@@ -380,7 +384,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "HELLO WORLD")
@@ -391,7 +395,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "11")
@@ -402,7 +406,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "hello world")
@@ -413,7 +417,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "HELLO WORLD")
@@ -424,7 +428,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         self.assertEqual(result, "Hello World")
@@ -434,7 +438,7 @@ class TestTemplatingNormalMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="normal",
         )
         # The filtered list will join a single email into a string, and then multiply by 2 to give 4.
@@ -473,7 +477,7 @@ class TestTemplatingTableMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="table",
         )
         expected = self.now.strftime("%B %d, %Y")
@@ -485,7 +489,7 @@ class TestTemplatingTableMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="table",
         )
         expected = [str(u.email) for u in self.program["users"]]
@@ -497,7 +501,7 @@ class TestTemplatingTableMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="table",
         )
         # Expect a list with one entry per user.
@@ -510,7 +514,7 @@ class TestTemplatingTableMode(unittest.TestCase):
             process_text(
                 tpl,
                 self.context,
-                perm_user=None,
+                check_permissions=None,
                 mode="table",
             )
 
@@ -520,7 +524,7 @@ class TestTemplatingTableMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="table",
         )
         self.assertEqual(result, "100")
@@ -531,7 +535,7 @@ class TestTemplatingTableMode(unittest.TestCase):
         result = process_text(
             tpl,
             self.context,
-            perm_user=None,
+            check_permissions=None,
             mode="table",
         )
         self.assertEqual(result, ["100"])
@@ -547,10 +551,11 @@ class TestTemplatingTableMode(unittest.TestCase):
         denier = DenyAllUser()
         tpl = "{{ program.users.email }}"
         with self.assertRaises(PermissionDeniedException):
+            check_permissions = lambda obj: has_view_permission(obj, denier)
             process_text(
                 tpl,
                 self.context,
-                perm_user=denier,
+                check_permissions=check_permissions,
                 mode="table",
             )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,15 @@
+def is_django_object(obj):
+    return hasattr(obj, "_meta")
+
+
+def has_view_permission(obj, perm_user):
+    """
+    If perm_user is None, returns False.
+    For Django-like objects (with _meta), returns perm_user.has_perm("view", obj).
+    For all other objects, returns True.
+    """
+    if perm_user is None:
+        return False
+    if is_django_object(obj):
+        return perm_user.has_perm("view", obj)
+    return True


### PR DESCRIPTION
Transition from using `perm_user` to a `check_permissions` function for permission checks across the templating and office renderer modules. This change enhances flexibility and consistency in permission handling.