### PR TITLE
Fix PyPI trusted publishing and bump Actions to Node.js 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           # cache: 'pip'
@@ -118,18 +118,16 @@ jobs:
           git push origin v${{ steps.versioning.outputs.newVersion }}
 
       - name: Create GitHub Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.versioning.outputs.newVersion }}
-          name: v${{ steps.versioning.outputs.newVersion }}
-          draft: false
-          prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-          generate_release_notes: true
+        run: |
+          gh release create \
+            "v${{ steps.versioning.outputs.newVersion }}" \
+            --title "v${{ steps.versioning.outputs.newVersion }}" \
+            --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout the merged development branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }} # This is the branch that was merged into main
           fetch-depth: 0 # Fetch all history for all branches and tags
@@ -144,39 +142,3 @@ jobs:
           # If conflicts arise and are resolved, or if no conflicts occur, proceed to push
           git push origin HEAD:${{ github.head_ref }}
 
-      - name: Build release distributions
-        run: |
-          python -m pip install build
-          python -m build
-
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-
-  publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    
-    needs:
-      - build-new-version
-    
-    runs-on: ubuntu-latest
-    
-    environment:
-      name: pypi
-      url: https://pypi.org/p/django-template-reports
-    
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-    
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-      
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish to PyPI
+
+on:
+  workflow_run:
+    workflows: ["Release New Version"]
+    types: [completed]
+
+jobs:
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-template-reports
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Checkout latest version tag
+        run: git checkout $(git describe --tags --abbrev=0)
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Build release distributions
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.12"
 dependencies = [
   "Django>=5,<6",
   "swapper>=1,<2",
-  "office-templates>=0.5",
+  "office-templates>=0.5,<0.6",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Generates reports (PPTX) from template files that are flexibly po
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-  "Django>=5.2.13,<7",
+  "Django>=5.2.13,<6",
   "swapper>=1,<2",
   "office-templates>=0.5,<0.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Generates reports (PPTX) from template files that are flexibly po
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-  "Django>=5,<6",
+  "Django>=5.2.13,<7",
   "swapper>=1,<2",
   "office-templates>=0.5,<0.6",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,33 +1,33 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
 name = "asgiref"
-version = "3.8.1"
+version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/38/b3395cc9ad1b56d2ddac9970bc8f4141312dbaec28bc7c218b0dfafd0f42/asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590", size = 35186, upload-time = "2024-03-22T14:39:36.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/e3/893e8757be2612e6c266d9bb58ad2e3651524b5b40cf56761e985a28b13e/asgiref-3.8.1-py3-none-any.whl", hash = "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47", size = 23828, upload-time = "2024-03-22T14:39:34.521Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
 ]
 
 [[package]]
 name = "django"
-version = "5.2.1"
+version = "5.2.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/10/0d546258772b8f31398e67c85e52c66ebc2b13a647193c3eef8ee433f1a8/django-5.2.1.tar.gz", hash = "sha256:57fe1f1b59462caed092c80b3dd324fd92161b620d59a9ba9181c34746c97284", size = 10818735, upload-time = "2025-05-07T14:06:17.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368, upload-time = "2026-04-07T14:02:15.072Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/92/7448697b5838b3a1c6e1d2d6a673e908d0398e84dc4f803a2ce11e7ffc0f/django-5.2.1-py3-none-any.whl", hash = "sha256:a9b680e84f9a0e71da83e399f1e922e1ab37b2173ced046b541c72e1589a5961", size = 8301833, upload-time = "2025-05-07T14:06:10.955Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b1/51ab36b2eefcf8cdb9338c7188668a157e29e30306bfc98a379704c9e10d/django-5.2.13-py3-none-any.whl", hash = "sha256:5788fce61da23788a8ce6f02583765ab060d396720924789f97fa42119d37f7a", size = 8310982, upload-time = "2026-04-07T14:02:08.883Z" },
 ]
 
 [[package]]
 name = "django-template-reports"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -42,8 +42,8 @@ xlsx = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=5,<6" },
-    { name = "office-templates", specifier = ">=0.5" },
+    { name = "django", specifier = ">=5.2.13,<6" },
+    { name = "office-templates", specifier = ">=0.5,<0.6" },
     { name = "office-templates", extras = ["xlsx"], marker = "extra == 'xlsx'" },
     { name = "swapper", specifier = ">=1,<2" },
 ]


### PR DESCRIPTION
## Summary
- Bumped `actions/checkout` from v4 to v6 and `actions/setup-python` from v5 to v6 to use Node.js 24 runtimes
- Replaced `softprops/action-gh-release@v2` with a `gh release create` shell command in the release workflow
- Extracted PyPI publishing into a separate `publish.yml` workflow triggered by `workflow_run`, enabling trusted publishing via OIDC (no shared artifacts needed)

## Test plan
- [ ] Verify the "Release New Version" workflow runs successfully on a merged PR to main
- [ ] Verify the "Publish to PyPI" workflow triggers after the release workflow completes and publishes the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)